### PR TITLE
fix: archive filter respected from palette + mobile palette UX (closes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,33 @@
-# mamoc.blog
+<div align="center">
 
-Long-form research blog by Cameron Michie & Alexander Cheetham — math, simulation, and the data they produce.
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="public/images/mamoc-text-dark.png">
+    <img alt="MAMOC" src="public/images/mamoc-text.png" width="520">
+  </picture>
+
+  <p><em>Long-form research blog by Cameron Michie &amp; Alexander Cheetham — math, simulation, and the data they produce.</em></p>
+
+  <p>
+    <img src="public/images/cam.png" alt="Cameron Michie" width="72" height="72">
+    &nbsp;&nbsp;
+    <img src="public/images/alex.png" alt="Alexander Cheetham" width="72" height="72">
+  </p>
+
+  <sub>Cameron Michie · Alexander Cheetham</sub>
+
+</div>
+
+---
 
 ## Stack
 
-- Next.js 16 · App Router · TypeScript
+- Next.js 16 · App Router · TypeScript · Turbopack
 - MDX via `@next/mdx` (build-time, file-based) — posts live in `content/posts/*.mdx`
 - Sass + CSS Modules (component-scoped) on a token-driven design system in `styles/global.scss`
 - `next-themes` for light/dark/system theme · `cmdk` for the ⌘K palette
 - KaTeX (math) · `rehype-prism-plus` (code) · Ably (realtime sims)
 - Self-hosted Google Fonts via `next/font/google` (Fira Code + Source Serif 4)
+- Playwright e2e suite (chromium / firefox / webkit / mobile-chrome) with per-PR video reports
 
 ## Prerequisites
 
@@ -27,21 +45,25 @@ npm install
 ## Run
 
 ```bash
-npm run dev        # http://localhost:3000
-npm run build      # production build
-npm run start      # serve the production build
-npm run typecheck  # tsc --noEmit
+npm run dev          # http://localhost:3000
+npm run build        # production build
+npm run start        # serve the production build
+npm run typecheck    # tsc --noEmit
+npm run test:e2e     # Playwright suite
+npm run test:e2e:ui  # Playwright UI mode
 ```
+
+`typecheck` is the only static check; there is no lint script.
 
 ## Routes
 
 | Path | Notes |
 |---|---|
 | `/` | Frontpage (zine layout, hero + sidebar + numbered index) |
-| `/posts/[slug]` | Per-post page — masthead + MDX body + subscribe block |
+| `/posts/[slug]` | Per-post page — masthead + MDX body |
 | `/archive` | All posts, organised by year, filterable by topic |
 | `/authors/[slug]` | Author profile + their posts |
-| `/about` | About + colophon |
+| `/about` | About + colophon (fully derived — see `lib/colophon.ts`) |
 | `/api/ably-token-request` | Ably token endpoint for the spatial-ecology sim |
 
 ## Authoring a post
@@ -49,17 +71,21 @@ npm run typecheck  # tsc --noEmit
 1. Drop a new `.mdx` file into `content/posts/<slug>.mdx`.
 2. Top of the file: an `export const metadata = {}` block (NOT YAML frontmatter — `@next/mdx` reads ESM exports). Required: `title`, `date` (`YYYY-MM-DD`), `summary`, `author`. Optional: `imageSrc`, `topics: []`, `featured: true`, `math: true`.
 3. Add a blank line between the metadata export and the first markdown content.
-4. Body is plain Markdown plus any of the components mapped in `mdx-components.tsx`: `Image`, `Link`, `Figure`, `ButtonTimer`, `LotkaVolterra`, `RK4ReactionDiffusion`, `CharacteristicLengthCalculator`, `WFCCONTAINER`. The interactive ones are wrapped in `dynamic({ ssr: false })` because they touch browser APIs at import.
+4. Body is plain Markdown plus any of the components mapped in `mdx-components.tsx`: `Image`, `Link`, `Figure`, the `Table` family (`Table`, `TableHeader`, `TableBody`, `TableFooter`, `TableHead`, `TableRow`, `TableCell`, `TableCaption`), `ButtonTimer`, `LotkaVolterra`, `RK4ReactionDiffusion`, `CharacteristicLengthCalculator`, `WFCCONTAINER`. The interactive ones are wrapped in `dynamic({ ssr: false })` because they touch browser APIs at import.
 
 The post automatically appears in the Frontpage index, the Archive, and (filtered by `author`) on the relevant `/authors/[slug]` page.
 
 ## Adding an author
 
-Edit `lib/authors.ts`, add a new key under `AUTHORS`. The author's profile page at `/authors/<slug>` is built automatically from `generateStaticParams`.
+Edit `lib/authors.ts`, add a new key under `AUTHORS`. The author's profile page at `/authors/<slug>` is built automatically from `generateStaticParams`. The `author` string in post metadata must match an `AUTHORS[*].name` exactly.
 
 ## Theming
 
 Theme state is managed by `next-themes` with three modes (`light`, `dark`, `system`). The toggle lives in `SiteHeader`'s segmented control. Tokens flip via `[data-theme="dark"]` selectors in `styles/global.scss`.
+
+## Testing
+
+Playwright runs on every PR via `.github/workflows/playwright.yml` across chromium, firefox, webkit, and a Pixel 5 mobile-chrome target. The workflow stitches per-browser videos into a single MP4 + animated WebP and upserts it as a PR comment. Only tests tagged `@multistep` are included in the combined video — see `CLAUDE.md` for the tagging convention and when it applies.
 
 ## Environment
 
@@ -80,7 +106,7 @@ components/
   chrome/               SiteHeader, SiteFooter, CommandPalette
   pages/                Frontpage, ArchivePage, AuthorPage, AboutPage
   post/                 PostSummary masthead
-  marketing/            SubscribeBlock
+  marketing/            SubscribeBlock (kept; currently unmounted — see CLAUDE.md)
   theme/                next-themes wrapper
   interactive/          chart / sim components (with _dynamic/ wrappers)
   frames/, WFC_components/  miscellaneous content components
@@ -88,16 +114,20 @@ content/posts/          .mdx posts
 lib/
   posts.ts              slug + metadata reads
   authors.ts            author registry
+  colophon.ts           derives /about facts from package.json, AUTHORS, posts, env
   site.ts               site-wide config strings
 styles/
   global.scss           tokens + element defaults
   variables.scss        legacy spacing/breakpoint Sass vars
   post.module.scss      legacy interactive-component styles
+tests/e2e/              Playwright specs (mobile.spec.ts targets the mobile project)
 mdx-components.tsx      MDX component map (server, imports client wrappers)
 next.config.mjs         createMDX with Turbopack-compatible string plugins
+playwright.config.ts    browser projects + video:'on'
 ```
 
 ## Notes
 
 - Turbopack is the default builder in Next 16; remark/rehype plugins must be specified as STRING names in `next.config.mjs` (no imported function references).
-- `tsconfig.json` keeps `strict: true` but has `noImplicitAny: false` and skips `noUncheckedIndexedAccess` / `noUnused*` — pre-existing legacy interactive components have implicit-any errors that aren't worth fixing in the redesign PR. Ratchet up in a follow-up.
+- `tsconfig.json` keeps `strict: true` but has `noImplicitAny: false` and skips `noUncheckedIndexedAccess` / `noUnused*` — legacy interactive components have implicit-any errors that aren't worth fixing piecemeal.
+- Newsletter signup and RSS/Atom/JSON feeds are currently disabled in the UI; see the TODO at the bottom of `CLAUDE.md` for the re-enable checklist.

--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 import { getSortedPostsData } from '@/lib/posts';
 import { ArchivePage } from '@/components/pages/ArchivePage';
 
@@ -12,5 +13,9 @@ export default async function Page() {
   const counts = new Map<string, number>();
   posts.forEach((p) => p.topics?.forEach((t) => counts.set(t, (counts.get(t) ?? 0) + 1)));
   const topicCounts = [...counts.entries()].sort((a, b) => b[1] - a[1]);
-  return <ArchivePage posts={posts} topicCounts={topicCounts} />;
+  return (
+    <Suspense fallback={null}>
+      <ArchivePage posts={posts} topicCounts={topicCounts} />
+    </Suspense>
+  );
 }

--- a/components/chrome/CommandPalette.module.scss
+++ b/components/chrome/CommandPalette.module.scss
@@ -32,12 +32,32 @@
   animation: slideIn 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 
   [data-theme='dark'] & { background: #161618; border-color: #2a2a2a; }
+
+  /* Mobile/small-viewport pattern: render as a bottom-anchored sheet rather
+     than a centered modal. Matches the shadcn responsive Dialog→Drawer
+     convention and Notion's mobile palette behaviour. CSS-only swap (no
+     useMediaQuery hook) avoids SSR hydration mismatch. */
+  @media (max-width: 640px) {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    transform: none;
+    width: 100%;
+    max-width: 100%;
+    border-radius: 16px 16px 0 0;
+    border-bottom: 0;
+    animation: slideUp 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+  }
 }
 
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 @keyframes slideIn {
   from { opacity: 0; transform: translate(-50%, -8px); }
   to { opacity: 1; transform: translate(-50%, 0); }
+}
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 .hd {
@@ -80,11 +100,21 @@
     border-radius: 3px;
     [data-theme='dark'] & { border-color: #333; }
   }
+
+  /* Keycap hints (↑↓ ↵ esc) have no meaning without a physical keyboard. */
+  @media (max-width: 640px) { display: none; }
 }
 
 .list {
   max-height: 60vh;
   overflow-y: auto;
+
+  /* On mobile we own the bottom of the screen; let the list grow to fit
+     while leaving room for the input header and the device's bottom UI.
+     `dvh` accounts for the dynamic viewport (URL bar collapse on iOS). */
+  @media (max-width: 640px) {
+    max-height: calc(100dvh - 140px);
+  }
 }
 
 .empty {
@@ -172,4 +202,7 @@
     margin: 0 3px;
     [data-theme='dark'] & { border-color: #333; }
   }
+
+  /* The footer is a keyboard-hint surface; hide on touch viewports. */
+  @media (max-width: 640px) { display: none; }
 }

--- a/components/pages/ArchivePage.tsx
+++ b/components/pages/ArchivePage.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { format, parseISO } from 'date-fns';
 import type { Post } from '@/lib/posts';
 import styles from './ArchivePage.module.scss';
@@ -20,7 +21,31 @@ function readingTime(): string {
 }
 
 export function ArchivePage({ posts, topicCounts }: Props) {
-  const [activeTopic, setActiveTopic] = useState<string | null>(null);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const urlTopic = searchParams.get('topic');
+
+  // Local state stays the source of truth for rendering so chip clicks update
+  // synchronously without waiting for a router round-trip. We mirror it to the
+  // URL via router.replace (so deep-linking + the command palette's
+  // `/archive?topic=…` navigation works), and in turn sync FROM the URL when
+  // it changes from outside this component (e.g. the palette while we're
+  // already mounted on /archive, or back/forward).
+  const [activeTopic, setActiveTopicState] = useState<string | null>(urlTopic);
+
+  useEffect(() => {
+    setActiveTopicState(urlTopic);
+  }, [urlTopic]);
+
+  const setActiveTopic = (next: string | null) => {
+    setActiveTopicState(next);
+    const params = new URLSearchParams(searchParams.toString());
+    if (next) params.set('topic', next);
+    else params.delete('topic');
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  };
 
   const visible = useMemo(
     () => (activeTopic ? posts.filter((p) => p.topics?.includes(activeTopic)) : posts),

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -43,6 +43,21 @@ test.describe('Mobile · Pixel 5', () => {
     const input = page.getByPlaceholder(/search posts/i);
     await expect(input).toBeVisible({ timeout: 5_000 });
 
+    // On mobile the palette renders as a bottom-anchored sheet, not a
+    // centered modal. Assert that the dialog content sits at the bottom of
+    // the viewport and spans its full width — that's the visual contract of
+    // the @media (max-width: 640px) styles in CommandPalette.module.scss.
+    const dialogBox = await page.locator('[cmdk-dialog]').boundingBox();
+    const viewport = page.viewportSize();
+    expect(dialogBox).not.toBeNull();
+    expect(viewport).not.toBeNull();
+    if (dialogBox && viewport) {
+      // Sheet hugs the bottom edge (within 2px of viewport bottom).
+      expect(dialogBox.y + dialogBox.height).toBeGreaterThanOrEqual(viewport.height - 2);
+      // Sheet spans the full viewport width.
+      expect(dialogBox.width).toBe(viewport.width);
+    }
+
     await input.fill('wave');
     await expect(
       page.getByRole('option').filter({ hasText: /wave function collapse/i }).first(),

--- a/tests/e2e/multistep.spec.ts
+++ b/tests/e2e/multistep.spec.ts
@@ -75,6 +75,68 @@ test.describe('Command palette', () => {
     await page.keyboard.press('Enter');
     await expect(page).toHaveURL(/\/posts\/wfc/);
   });
+
+  test('selecting a topic in the palette lands on archive with that filter pre-applied @multistep', async ({ page }) => {
+    await page.goto('/');
+
+    // The palette's `mod+k` handler is registered in a useEffect — waiting for
+    // the visible palette trigger guarantees hydration has completed so the
+    // keypress will actually be heard.
+    await expect(page.getByRole('button', { name: /search palette/i })).toBeVisible();
+    await page.keyboard.press(`${MOD}+k`);
+
+    const input = page.getByPlaceholder(/search posts/i);
+    await expect(input).toBeVisible({ timeout: 5_000 });
+
+    // Filter the palette down to rows containing "simulation". cmdk's
+    // accessible name for the topic row is `§ #simulation N posts topic`,
+    // which uniquely contains `#simulation` (post rows render the bare topic
+    // name as a tag, never prefixed with `#`).
+    await input.fill('simulation');
+
+    const topicRow = page.getByRole('option', { name: /#simulation/i });
+    await expect(topicRow).toBeAttached();
+    // Click rather than Enter — cmdk's selection cursor sits on the first
+    // post row, not the topic row, and ArrowDown'ing past 7 posts is fragile.
+    // Click auto-scrolls into view.
+    await topicRow.click();
+
+    // Lands on /archive with ?topic=simulation in the URL.
+    await expect(page).toHaveURL(/\/archive\?topic=simulation/);
+    await expect(page.getByRole('heading', { name: /archive/i })).toBeVisible();
+
+    // The filter is applied behaviourally: the post count on this filtered
+    // visit is strictly less than the unfiltered post count. The mirror
+    // assertion in the "Archive topic filter" test above relies on the same
+    // content invariant — at least one post tagged `simulation`, at least one
+    // not — so if that invariant breaks, both tests fail loudly.
+    const filteredCount = await page.locator('a[href^="/posts/"]').count();
+    expect(filteredCount).toBeGreaterThan(0);
+
+    await page.goto('/archive');
+    await expect(page.getByRole('heading', { name: /archive/i })).toBeVisible();
+    const totalCount = await page.locator('a[href^="/posts/"]').count();
+    expect(filteredCount).toBeLessThan(totalCount);
+  });
+});
+
+test.describe('Archive deep-link', () => {
+  test('visiting /archive?topic=… directly applies the filter on first paint @multistep', async ({ page }) => {
+    // Independent of the palette flow: a shared link or bookmark to
+    // /archive?topic=simulation must apply the filter on the very first
+    // render. This exercises the `useSearchParams` initial-read path in
+    // ArchivePage that the palette test only covers indirectly.
+    await page.goto('/archive?topic=simulation');
+    await expect(page.getByRole('heading', { name: /archive/i })).toBeVisible();
+
+    const filteredCount = await page.locator('a[href^="/posts/"]').count();
+    expect(filteredCount).toBeGreaterThan(0);
+
+    await page.goto('/archive');
+    await expect(page.getByRole('heading', { name: /archive/i })).toBeVisible();
+    const totalCount = await page.locator('a[href^="/posts/"]').count();
+    expect(filteredCount).toBeLessThan(totalCount);
+  });
 });
 
 test.describe('Theme switcher', () => {


### PR DESCRIPTION
## Summary

Resolves #8.

- **Archive filter is respected when arriving from the command palette.** `ArchivePage` now reads `?topic=` from the URL on first render, so `/archive?topic=ml` lands with the `#ml` chip already active. Local `useState` stays the source of truth for snappy chip clicks; a `useEffect` mirrors external URL changes (palette navigation while already on `/archive`, back/forward); chip clicks reflect to the URL via `router.replace`.
- **Alternate palette UI on tablet/phone.** At ≤640px the palette renders as a bottom-anchored sheet rather than a centered modal — matches the shadcn responsive Dialog→Drawer convention and Notion's mobile palette behaviour. CSS-only (no `useMediaQuery` hook) avoids SSR hydration mismatch. Keyboard hint chips (`↑↓`, `↵`, `esc`, `⌘K`) are hidden at the same breakpoint since they have no meaning without a physical keyboard.
- **README refresh** (separate commit): mamoc wordmark + author avatars at the top via GitHub's `<picture>` for auto light/dark swap; plus stale-content fixes (test commands, removed subscribe-block reference, full Table component family, `lib/colophon.ts` in layout, etc.).

The trigger button (`find ⌘K` → icon on mobile) is deliberately **out of scope** here — PR #15 owns that under issue #10.

## Test plan

- [x] `npm run typecheck` clean
- [x] New `@multistep` test (`tests/e2e/multistep.spec.ts`): palette → topic row → `/archive?topic=…` with filter behaviourally applied
- [x] New `@multistep` deep-link test: direct visit to `/archive?topic=simulation` applies filter on first paint
- [x] Extended mobile palette test (`tests/e2e/mobile.spec.ts`) asserts the dialog hugs the viewport bottom and spans full width on a Pixel 5
- [x] Existing `Archive topic filter` chip-click test still passes (synchronous local-state design preserved)
- [ ] Manual: verify on real mobile that the bottom sheet keyboard doesn't cover the input (`dvh` handles the dynamic viewport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)