### PR TITLE
fix(wfc): respect biome distribution + widget overhaul (closes #16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ The MDX renderer is told which custom React components are usable inside posts. 
 
 ### TypeScript strictness — deliberately loose
 
-`tsconfig.json:18-19` keeps `strict: true` but disables `noImplicitAny`, and there's no `noUnused*` / `noUncheckedIndexedAccess`. This is because legacy interactive components (the `WFC_components/`, older chart wrappers) have implicit-any errors that aren't worth fixing piecemeal. Don't tighten these flags without a sweep — turning on `noImplicitAny` alone produces dozens of errors.
+`tsconfig.json:18-19` keeps `strict: true` but disables `noImplicitAny`, and there's no `noUnused*` / `noUncheckedIndexedAccess`. This is because older chart wrappers have implicit-any errors that aren't worth fixing piecemeal. Don't tighten these flags without a sweep — turning on `noImplicitAny` alone produces dozens of errors.
 
 ### Styling
 

--- a/components/WFC_components/WFCCONTAINER.tsx
+++ b/components/WFC_components/WFCCONTAINER.tsx
@@ -69,6 +69,26 @@ export default function WFCCONTAINER() {
         </div>
 
         <div className="wfc-stage">
+          {/* Help panel: hidden in step 1, revealed by wfc_flow.js once a
+              tileset is selected. <details> drives the collapse/expand
+              natively — no JS state to keep in sync. */}
+          <details id="wfc-help" className="wfc-help" hidden>
+            <summary className="wfc-help-summary">
+              <span>How to use this demo</span>
+              <span className="wfc-help-toggle" aria-hidden>+</span>
+            </summary>
+            <ul className="wfc-help-list">
+              <li><b>Grid size</b> — drag the slider to choose how many cells the canvas is divided into.</li>
+              <li><b>Run / Restart</b> — kick off a new collapse with your current weights. Your seed determines the outcome.</li>
+              <li><b>Pause / Play</b> — freeze the algorithm to study an in-progress state, then resume.</li>
+              <li><b>Step ▶|</b> — advance exactly one cell-collapse (also pauses auto-run so you can step further).</li>
+              <li><b>Speed</b> — slow the auto-loop down to watch constraint propagation move across the grid.</li>
+              <li><b>Click an uncollapsed cell</b> on the canvas to choose its tile manually — the algorithm propagates from your pick.</li>
+              <li><b>Seed</b> — same number = same run. <b>Share</b> copies a URL that reproduces this run on someone else's machine.</li>
+              <li><b>Save PNG</b> — download the completed grid as an image.</li>
+            </ul>
+          </details>
+
           <div id="tileselect">
             <p className="wfc-step"><b>step 1</b> · pick a tileset</p>
             <div className="images" />

--- a/public/WFC_code/wfc.css
+++ b/public/WFC_code/wfc.css
@@ -76,6 +76,57 @@
   width: 100%;
 }
 
+/* How-to-use info panel (revealed from step 2 onwards) ---------------- */
+
+.wfc-help {
+  margin: 0 0 16px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-md);
+  background: var(--color-white);
+  overflow: hidden;
+}
+[data-theme='dark'] .wfc-help {
+  background: #161618;
+  border-color: #2a2a2a;
+}
+.wfc-help-summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 10px 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-gray-dark);
+  user-select: none;
+}
+.wfc-help-summary::-webkit-details-marker { display: none; }
+.wfc-help-summary:hover { color: var(--color-primary); }
+.wfc-help[open] .wfc-help-summary { border-bottom: 1px solid var(--color-border); }
+[data-theme='dark'] .wfc-help[open] .wfc-help-summary { border-bottom-color: #2a2a2a; }
+.wfc-help-toggle {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  text-align: center;
+  line-height: 16px;
+  font-size: 14px;
+  color: var(--color-primary);
+}
+.wfc-help[open] .wfc-help-toggle { transform: rotate(45deg); }
+.wfc-help-list {
+  margin: 0;
+  padding: 12px 16px 14px 32px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--color-gray-dark);
+}
+.wfc-help-list li { margin-bottom: 4px; }
+.wfc-help-list b { color: var(--color-primary); font-weight: 700; }
+
 /* Tileset picker --------------------------------------------------------- */
 
 .images {
@@ -292,8 +343,278 @@
   border-color: var(--color-secondary);
 }
 
+/* Primary controls (step 3 first row): grid-size label + slider +
+   readout + the Run/Restart button.
+
+   Wrapping these in a stable container guarantees the p5-created
+   bslider sits next to its readout instead of migrating to the end of
+   #wfc-controls on every startWFC. */
+
+.wfc-primary {
+  flex-basis: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.wfc-primary > .wfc-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-gray);
+}
+
+.wfc-primary input[type='range'] {
+  flex: 1;
+  min-width: 140px;
+  max-width: 240px;
+  accent-color: var(--color-primary);
+}
+
+.wfc-primary p {
+  margin: 0;
+  min-width: 28px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+/* The Run / Restart button — primary affordance during step 3. */
+.wfc-primary .wfc-run-button {
+  margin-left: auto;
+}
+
+/* Run-extras: speed/step/seed/share/save (step 3 second row) ----------- */
+
+.wfc-extras {
+  flex-basis: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--color-border);
+}
+
+.wfc-extras .wfc-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.wfc-extras .wfc-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--color-gray);
+  text-transform: uppercase;
+}
+
+.wfc-extras .wfc-num {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  font-size: 11px;
+  color: var(--color-primary);
+  min-width: 42px;
+}
+
+.wfc-extras input[type='number'] {
+  font-family: inherit;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  padding: 4px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
+  background: var(--color-white);
+  color: var(--color-gray-dark);
+  width: 130px;
+}
+[data-theme='dark'] .wfc-extras input[type='number'] {
+  background: #161618;
+  border-color: #2a2a2a;
+  color: #d6d6d6;
+}
+
+.wfc-extras button {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-gray-dark);
+  padding: 5px 12px;
+  border-radius: var(--border-radius-sm);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: var(--transition-base);
+}
+.wfc-extras button:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+.wfc-extras button:disabled { opacity: 0.6; cursor: default; }
+
+/* Step is the primary control during step 3 — the headline button for
+   educational use. Filled, primary-coloured so readers find it first. */
+.wfc-extras #wfc-step {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+  padding: 5px 14px;
+}
+.wfc-extras #wfc-step:hover:not(:disabled) {
+  background: var(--color-secondary);
+  border-color: var(--color-secondary);
+  color: #fff;
+}
+
+/* Click-to-collapse popover ------------------------------------------- */
+
+#wfc-canvas { position: relative; }
+
+.wfc-popover {
+  position: absolute;
+  z-index: 10;
+  min-width: 200px;
+  max-width: 320px;
+  padding: 10px 12px 12px;
+  background: var(--color-white);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--border-radius-md);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  font-family: var(--font-family-primary);
+}
+[data-theme='dark'] .wfc-popover {
+  background: #161618;
+  border-color: var(--color-primary);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+}
+
+.wfc-popover-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-gray);
+  margin-bottom: 8px;
+  padding-right: 18px;
+}
+
+.wfc-popover-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
+  gap: 6px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.wfc-popover-grid img {
+  width: 100%;
+  height: 40px;
+  object-fit: contain;
+  image-rendering: pixelated;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
+  background: var(--color-gray-vvvvlight);
+  cursor: pointer;
+  transition: var(--transition-base);
+}
+.wfc-popover-grid img:hover {
+  border-color: var(--color-primary);
+  transform: scale(1.06);
+}
+[data-theme='dark'] .wfc-popover-grid img {
+  background: #0f0f10;
+  border-color: #2a2a2a;
+}
+
+.wfc-popover-close {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-gray);
+  font-size: 14px;
+  line-height: 22px;
+  cursor: pointer;
+  border-radius: 50%;
+}
+.wfc-popover-close:hover { background: var(--color-gray-vvvvlight); color: var(--color-primary); }
+
 @media (max-width: 768px) {
   .wfc-stage { padding: 14px 12px; }
   .images { grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 8px; }
   .prob-row { grid-template-columns: 32px 1fr 1.5fr 48px; gap: 8px; }
+  .wfc-extras input[type='number'] { width: 100px; }
+  .wfc-help-list { padding: 12px 14px 14px 28px; font-size: 12.5px; }
+}
+
+/* Mobile-only refinements: bottom-sheet popover, larger tappable
+   controls, and friendlier wrapping for the run-extras row. */
+@media (max-width: 640px) {
+  /* Popover: pin to viewport bottom as a full-width sheet so a tap
+     near the edge of a small canvas doesn't leave half the choices
+     off-screen. CSS supersedes the JS inline left/top — see the
+     `isMobile` branch in openPopoverForCell. */
+  .wfc-popover {
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: auto;
+    bottom: 0;
+    width: 100vw;
+    max-width: none;
+    min-width: 0;
+    max-height: 60vh;
+    border-radius: var(--border-radius-md) var(--border-radius-md) 0 0;
+    box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.25);
+    padding: 14px 14px calc(14px + env(safe-area-inset-bottom, 0px));
+    overflow-y: auto;
+  }
+  .wfc-popover-grid {
+    grid-template-columns: repeat(auto-fill, minmax(54px, 1fr));
+    gap: 8px;
+    max-height: 44vh;
+  }
+  .wfc-popover-grid img { height: 54px; }
+
+  /* Larger touch targets across the run controls. */
+  .wfc-extras button {
+    padding: 9px 14px;
+    font-size: 12px;
+    min-height: 38px;
+  }
+  .wfc-extras input[type='number'] {
+    padding: 7px 9px;
+    min-height: 36px;
+    width: 100px;
+  }
+  .wfc-extras .wfc-row { gap: 8px; }
+  .wfc-extras .wfc-label { flex-basis: 100%; }
+  /* Speed slider needs room to drag on mobile. */
+  .wfc-extras #wfc-speed { flex: 1 1 100%; max-width: none; min-width: 0; }
+
+  /* Primary row: stack so the slider gets the full width and the Run
+     button doesn't get squeezed into a corner. */
+  .wfc-primary { gap: 8px 12px; }
+  .wfc-primary input[type='range'] {
+    flex: 1 1 100%;
+    max-width: none;
+  }
+  .wfc-primary .wfc-run-button {
+    margin-left: 0;
+    min-height: 40px;
+    padding: 8px 18px;
+  }
+
+  /* Toolbar reset chip — keep the tap target generous. */
+  .wfc-toolbar .resetButton { min-height: 34px; padding: 6px 12px; font-size: 12px; }
+
+  .wfc-help-summary { padding: 12px 14px; font-size: 12px; }
 }

--- a/public/WFC_code/wfc.js
+++ b/public/WFC_code/wfc.js
@@ -1,25 +1,106 @@
+'use strict';
+
+// Wave Function Collapse — vanilla JS + p5 global mode. Shares a few
+// top-level vars with wfc_flow.js (tileset, prob_distr) via window.
+// `var` at top level binds onto the global object so the cross-script
+// reads here pick up wfc_flow.js's assignments at runtime.
+
 var w = window.innerWidth;
 var h = window.innerHeight;
 var cnv_w = 600;
 var cnv_h = 400;
-var bslider
-var slider_text
-var status_button
-var step_button
-var status_bool = false
+var bslider;          // grid size slider (p5)
+var slider_text;      // grid size value readout (p5)
+var status_button;    // Start/Reset toggle (p5)
+var step_button;      // legacy unused; kept to preserve shape
+var status_bool = false;
 var grid_list = [];
 var gridimages = [];
-var testimage
+var testimage;
 var tracking = [];
-var global_options =[];
+var global_options = [];
 var old_grids = [];
 var backtracking = false;
 var slider_max = 30;
+var filled_count;
+var svgFilenames = [];
+
+// --- New: animation pacing + mixed-initiative state ---------------------
+
+let stepIntervalMs = 0;       // 0 = run flat-out; >0 throttles draw-loop steps
+let lastStepTime = 0;
+let isPaused = false;
+let forceStepOnce = false;    // one-shot from the Step button
+let recentBacktrack = null;   // { position, framesLeft } — for the red flash
+const BACKTRACK_FLASH_FRAMES = 18;
+let manualCollapseQueued = null; // { cell, tile } from click-to-collapse
+
+// --- Seeded RNG (mulberry32) -------------------------------------------
+
+// Pull initial seed from ?seed= so a run is shareable; otherwise mint one.
+let rngSeed = readSeedFromURL();
+let rng = mulberry32(rngSeed);
+
+function mulberry32(seed) {
+  let s = seed >>> 0;
+  return function () {
+    s = (s + 0x6D2B79F5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+function readSeedFromURL() {
+  try {
+    const p = new URLSearchParams(window.location.search);
+    const raw = p.get('seed');
+    if (raw !== null && raw !== '') {
+      const n = parseInt(raw, 10);
+      if (Number.isFinite(n)) return n >>> 0;
+    }
+  } catch (_) { /* SSR or sandboxed — fall through */ }
+  return (Math.random() * 0xFFFFFFFF) >>> 0;
+}
+function reseed(value) {
+  rngSeed = (value >>> 0);
+  rng = mulberry32(rngSeed);
+}
+function updateShareURL() {
+  try {
+    const u = new URL(window.location.href);
+    u.searchParams.set('seed', String(rngSeed));
+    window.history.replaceState({}, '', u.toString());
+  } catch (_) { /* no-op */ }
+}
+
+// --- Direction vectors --------------------------------------------------
+
+const CARD_DIRS = [[0, -1], [0, 1], [-1, 0], [1, 0]];
+const EIGHT_DIRS = [[0, -1], [0, 1], [-1, 0], [1, 0], [1, -1], [-1, -1], [1, 1], [-1, 1]];
+const dirsFor = () => (tileset.includes('CITY') ? EIGHT_DIRS : CARD_DIRS);
+
+// --- Grid helpers -------------------------------------------------------
+
+const samePos = (a, b) => a[0] === b[0] && a[1] === b[1];
+const findByPos = (grid, pos) => grid.find(c => samePos(c.position, pos));
+
+// Cheap deep-clone for backtracking snapshots. Drops the gridSquare class
+// identity (downstream code only touches plain fields), so a plain shape
+// is ~10x faster than JSON.parse(JSON.stringify(...)).
+function cloneGrid(grid) {
+  return grid.map(c => ({
+    position: c.position.slice(),
+    options: c.options.slice(),
+    underInspection: c.underInspection,
+    fixed: c.fixed,
+  }));
+}
 
 // Canvas dimensions track the #wfc-canvas host element so the demo fits the
 // post body instead of overflowing the viewport. Recomputed on resize.
 function computeCanvasSize() {
-  var host = document.getElementById('wfc-canvas');
+  const host = document.getElementById('wfc-canvas');
   if (host && host.clientWidth > 0) {
     cnv_w = host.clientWidth;
     cnv_h = Math.round(cnv_w * (2 / 3));
@@ -29,725 +110,1003 @@ function computeCanvasSize() {
   }
 }
 
+// --- Tile manifest ------------------------------------------------------
 
-var filled_count;
-
-
-var svgFilenames = [];
-
-
-
-// Tile manifest is rendered as a JSON blob inside <script id="imageholder">
-// by WFCCONTAINER.tsx. This used to be 128 hidden <img> tags, which the
-// browser preloaded on every page visit — the JSON form costs zero extra
-// HTTP requests until p5's loadImage() is called in setup().
 const manifestNode = document.getElementById('imageholder');
 let manifest = [];
 try {
   manifest = JSON.parse(manifestNode.textContent || '[]');
 } catch (e) {
-  // Surface a console.warn so a regression here is visible in DevTools
-  // instead of a silently empty tileset picker.
   console.warn('[wfc] tile manifest unreadable, falling back to empty', e);
 }
 manifest.forEach(src => {
-  // Strip everything before "/posts" to match the legacy relative-path
-  // format that the rest of wfc.js (and wfc_flow.js's CITY override) expect.
   const tail = src.split('/posts').pop();
   if (tail && (tail.endsWith('.svg') || tail.endsWith('.png'))) {
     svgFilenames.push('.' + tail);
   }
 });
-// createGrid (and any other downstream consumer) used to iterate over the
-// NodeList returned by querySelectorAll('img'); preserve that shape with a
-// tiny `{ src }` shim so existing code keeps working without rewrites.
 const svgImages = manifest.map(src => ({ src }));
+
+// `?autostart=0` opts out of the auto-run-on-STARTWFC behaviour. Used by
+// e2e tests that need a frozen post-STARTWFC state so they can poke at
+// grid_list / sample directly without the draw loop mutating it
+// underneath them.
+function shouldAutoStart() {
+  try {
+    const p = new URLSearchParams(window.location.search);
+    const v = p.get('autostart');
+    if (v === '0' || v === 'false') return false;
+  } catch (_) { /* SSR — fall through */ }
+  return true;
+}
 
 function startWFC() {
   try {
-    bslider.remove()
+    bslider.remove();
+  } catch (TypeError) {
+    // no-op: bslider may not exist on first run
   }
-  catch (TypeError) {
-  }
-  var max = tileset.includes('CITY') ? 8 : 30;
+  const max = tileset.includes('CITY') ? 32 : 30;
   bslider = createSlider(1, max, 2);
-  bslider.parent("wfc-controls")
-  createGrid(bslider.value(), true)
+  bslider.parent('wfc-primary');
+
+  // Keep bslider adjacent to its readout: position it after the "Grid
+  // size" label but before slider_text within the wfc-primary wrapper.
+  const primary = document.getElementById('wfc-primary');
+  if (primary && bslider.elt && slider_text && slider_text.elt) {
+    primary.insertBefore(bslider.elt, slider_text.elt);
+  }
+
+  // Full state reset so a second STARTWFC starts from scratch — without
+  // this, grid_list (and the canvas) still showed the completed grid
+  // from the previous run, and the Step/click pathways short-circuited
+  // on finishedCollapse(grid_list).
+  grid_list = createGrid(bslider.value(), true);
+  backtracking = false;
+  tracking = [];
+  old_grids = [];
+  recentBacktrack = null;
+  manualCollapseQueued = null;
+  forceStepOnce = false;
+  isPaused = false;
+
+  // Auto-run by default — clicking "start collapse →" should actually
+  // start the collapse, not just transition to step 3. Tests that need
+  // a frozen state use ?autostart=0.
+  const autostart = shouldAutoStart();
+  status_bool = autostart;
+  if (status_button) status_button.html(autostart ? 'Restart' : 'Run');
+
+  // Surface the run-extras UI now that we're entering step 3.
+  ensureRunControls();
+
+  // Sync the wfc-extras controls so they reflect the freshly-reset run
+  // state (Pause label, speed readout, seed input).
+  const playBtn = document.getElementById('wfc-play');
+  if (playBtn) playBtn.textContent = 'Pause';
+  const seedInput = document.getElementById('wfc-seed');
+  if (seedInput) seedInput.value = String(rngSeed);
+
+  // Belt-and-braces: re-bind the canvas click handler in case setup()'s
+  // attempt ran before the canvas was in the DOM.
+  bindCanvasClickHandler();
 }
 
-// Represents a square within the grid.
+// --- Classes ------------------------------------------------------------
+
 class gridSquare {
-constructor(position, options) {
-  this.position = position;  // Stores the position of the square within the grid of type [x,y]
-  this.options = options;  // Contains the possible values or options for the square
-  this.underInspection = false;  // Flags whether the square is currently being examined while solving
-  this.fixed = false;  // Indicates whether the value of the square has been definitively set
-}
+  constructor(position, options) {
+    this.position = position;
+    this.options = options;
+    this.underInspection = false;
+    this.fixed = false;
+  }
 }
 
-// Object for tracking information required for backtracking.
 class trackingObj {
-constructor(gridSquare, options) {
-  this.gridSquare = gridSquare;  // References the grid square being tracked
-  this.options = options;  // Stores the current possible options for the tracked square
-  this.indexes = [];  // Holds the options that have been tried
-}
+  constructor(gridSquare, options) {
+    this.gridSquare = gridSquare;
+    this.options = options;
+    this.indexes = [];
+  }
 }
 
-// Represents an error encountered when the propogationn algorithm causes a cell to have no remaining options.
 class optionsError extends Error {
-constructor(message, broken_cell, grid_list) {
-  super(message);  // Inherits from the base Error class
-  this.name = "OptionError";  // Specifies the error's name
-  this.broken_cell = broken_cell;  // References the grid square causing the error
-}
+  constructor(message, broken_cell, grid_list) {
+    super(message);
+    this.name = 'OptionError';
+    this.broken_cell = broken_cell;
+  }
 }
 
+// --- Rendering ----------------------------------------------------------
 
-// Function to visually render a grid of squares onto the canvas.
+// Heatmap: blue (low option count = constrained) → red (many options =
+// uncertain). Uncollapsed cells used to be flat black; this colours them
+// by entropy proxy so propagation is visible at a glance.
+function entropyColor(optCount, maxOpts) {
+  if (maxOpts <= 1) return [40, 40, 50];
+  const t = Math.max(0, Math.min(1, (optCount - 1) / (maxOpts - 1)));
+  // hue 220 (cool blue) → 0 (hot red); saturation/lightness fixed
+  const hue = 220 - 220 * t;
+  return hslToRgb(hue, 70, 38);
+}
+function hslToRgb(h, s, l) {
+  s /= 100; l /= 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hp = h / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let [r, g, b] = [0, 0, 0];
+  if (hp < 1)      [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else             [r, g, b] = [c, 0, x];
+  const m = l - c / 2;
+  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
+}
+
 function renderGrid(grid_array) {
-// Calculate grid dimensions
-var grid_size = Math.sqrt(grid_array.length);
-var [grid_w, grid_h] = [cnv_w / grid_size, cnv_h / grid_size];  // Adjust based on canvas size
+  const grid_size = Math.sqrt(grid_array.length);
+  const grid_w = cnv_w / grid_size;
+  const grid_h = cnv_h / grid_size;
+  const maxOpts = global_options.length || 1;
 
-// Iterate through each square in the grid
-for (let i = 0; i < grid_array.length; i++) {
-  // Get the square's position
-  var [x, y] = grid_array[i].position;
+  for (let i = 0; i < grid_array.length; i++) {
+    const [x, y] = grid_array[i].position;
+    const cell = grid_array[i];
 
-  // Render based on the number of options and state:
-
-  // If only one option (likely a solved square):
-  if (grid_array[i].options.length == 1) {
-    fill('black');       // Black background
-    strokeWeight(2);     // White border (default)
-    stroke('white');
-
-    // If the square is fixed (value cannot change):
-    if (grid_array[i].fixed == true) {
-      strokeWeight(2);  // Thicker blue border for emphasis
-      stroke('blue');
-    }
-
-    rect(x * grid_w, y * grid_h, grid_w, grid_h);  // Draw the square
-    strokeWeight(0);  // Reset stroke for text
-    image(gridimages[grid_array[i].options[0]], x * grid_w, y * grid_h, grid_w, grid_h);  // Display image based on option
-
-  // If no options (error or invalid state):
-  } else if (grid_array[i].options.length == 0) {
-    fill('orange');      // Orange background to indicate issue
-    rect(x * grid_w, y * grid_h, grid_w, grid_h);
-
-  // Otherwise (multiple options, unsolved):
-  } else {
-    fill('black');      // Black background
-    rect(x * grid_w, y * grid_h, grid_w, grid_h);
-  }
-
-  // Display text information for each square:
-  fill('white');         // White text for visibility
-  strokeWeight(0);       // No stroke for text
-  options_coords = grid_array[i].options.length.toString() //.concat(' ').concat(grid_array[i].position.toString());
-  // Display number of options and position coordinates
-  text(options_coords, (x + 0.1) * grid_w, (y + 0.1) * grid_h, grid_w, grid_h);
-}
-}
-
-// Function to create array representing the grid of gridSquare objects
-function createGrid(grid_size,tilebool=false) {
-// Initialize arrays to hold the grid and options
-let grid_array = [];
-let options = [];
-global_options = [];  // reset global options
-
-// Extract options from SVG images:
-svgImages.forEach(image => {
-  var filename =''
-  if (!tilebool) {
-    filename = image.src.split('/').pop();
-  } else {
-    if (image.src.includes(tileset)) {
-      filename = image.src.split('/').pop();
+    if (cell.options.length === 1) {
+      fill('black');
+      strokeWeight(2);
+      stroke('white');
+      if (cell.fixed === true) {
+        strokeWeight(2);
+        stroke('blue');
+      }
+      rect(x * grid_w, y * grid_h, grid_w, grid_h);
+      strokeWeight(0);
+      image(gridimages[cell.options[0]], x * grid_w, y * grid_h, grid_w, grid_h);
+    } else if (cell.options.length === 0) {
+      fill('orange');
+      strokeWeight(0);
+      rect(x * grid_w, y * grid_h, grid_w, grid_h);
     } else {
-      filename = '';
+      const [r, g, b] = entropyColor(cell.options.length, maxOpts);
+      fill(r, g, b);
+      strokeWeight(0);
+      rect(x * grid_w, y * grid_h, grid_w, grid_h);
+    }
+
+    // Backtracking flash overlay — paints the recently-broken cell red
+    // for BACKTRACK_FLASH_FRAMES frames so failed propagations are
+    // visible instead of flickering past in a single tick.
+    if (recentBacktrack && samePos(cell.position, recentBacktrack.position)) {
+      const alpha = Math.round(180 * (recentBacktrack.framesLeft / BACKTRACK_FLASH_FRAMES));
+      fill(220, 40, 40, alpha);
+      strokeWeight(0);
+      rect(x * grid_w, y * grid_h, grid_w, grid_h);
+    }
+
+    fill('white');
+    strokeWeight(0);
+    text(cell.options.length.toString(), (x + 0.1) * grid_w, (y + 0.1) * grid_h, grid_w, grid_h);
+  }
+
+  if (recentBacktrack) {
+    recentBacktrack.framesLeft -= 1;
+    if (recentBacktrack.framesLeft <= 0) recentBacktrack = null;
+  }
+}
+
+// --- Grid construction --------------------------------------------------
+
+function createGrid(grid_size, tilebool = false) {
+  const grid_array = [];
+  const options = [];
+  global_options = [];
+
+  svgImages.forEach(image => {
+    let filename = '';
+    if (!tilebool) {
+      filename = image.src.split('/').pop();
+    } else if (image.src.includes(tileset)) {
+      filename = image.src.split('/').pop();
+    }
+    if (filename.endsWith('.svg') || filename.endsWith('.png')) {
+      const stem = filename.split('.')[0];
+      options.push(stem);
+      global_options.push(stem);
+    }
+  });
+
+  for (let x = 0; x < grid_size; x++) {
+    for (let y = 0; y < grid_size; y++) {
+      grid_array.push(new gridSquare([x, y], options));
     }
   }
-  if (filename.endsWith('.svg')||filename.endsWith('.png')) {  // Check if it's an SVG file
-    options.push(filename.split('.')[0]);  // Add filename (without extension) as an option
-    global_options.push(filename.split('.')[0]);  // Add to global options as well
-  }
-});
 
-// Create grid squares:
-for (let x = 0; x < grid_size; x++) {
-  for (let y = 0; y < grid_size; y++) {
-    var temp_square = new gridSquare([x, y], options);  // Create a gridSquare object with position and options
-    grid_array.push(temp_square);  // Add the square to the grid array
-  }
+  return grid_array;
 }
 
-return grid_array;  // Return the created grid
-}
+// --- Constraint propagation primitives ---------------------------------
 
-// Simple "not" function
 const not = x => !x;
-
-// Identity function (returns input as-is)
 const identity = x => x;
 
-// Function to check a neighboring cell in a specific direction
 function checkDirection(direction, cell, grid_list, visited, in_visited = not) {
-// Direction format: [x offset, y offset] (e.g., N = [0, -1])
-
-// Calculate the new position based on direction
-let new_position = [direction[0] + cell.position[0], direction[1] + cell.position[1]];
-
-// Check if the new position is within the grid
-position_match = grid_list.some(cell => JSON.stringify(cell.position) == JSON.stringify(new_position));
-
-// Check if the new position is included or excluded in the "visited" list, based on the "in_visited" function
-visited_match = in_visited(visited.some(cell => JSON.stringify(cell.position) == JSON.stringify(new_position)));
-
-// If both conditions are met, return the cell at the new position
-if (position_match && visited_match) {
-  found_cell = grid_list.filter(cell => JSON.stringify(cell.position) === JSON.stringify(new_position))[0];
-  return found_cell;
-} else {
-  return false; // Indicate no valid cell found
-}
+  const new_position = [direction[0] + cell.position[0], direction[1] + cell.position[1]];
+  const position_match = grid_list.some(c => samePos(c.position, new_position));
+  const visited_match = in_visited(visited.some(c => samePos(c.position, new_position)));
+  if (position_match && visited_match) {
+    return findByPos(grid_list, new_position);
+  }
+  return false;
 }
 
-// Function to check if a cell is present in a list of grid cells
 function inArray(input_cell, grid_list) {
-// Compare cell positions for equality (using JSON.stringify for consistent comparison)
-return grid_list.some(cell => JSON.stringify(cell.position) == JSON.stringify(input_cell.position));
+  return grid_list.some(c => samePos(c.position, input_cell.position));
 }
 
-// Map to convert numerical direction pairs to letters
 const directionsMap = new Map([
-[[0, -1].toString(), "U"],  // Up
-[[0, 1].toString(), "D"],  // Down
-[[-1, 0].toString(), "L"],  // Left
-[[1, 0].toString(), "R"]   // Right
+  [[0, -1].toString(), 'U'],
+  [[0, 1].toString(), 'D'],
+  [[-1, 0].toString(), 'L'],
+  [[1, 0].toString(), 'R'],
 ]);
 
-// Function to obtain the letter representation of a direction
 function mapDirectionToLetter(direction) {
-// Access the corresponding letter from the directionsMap, or return false for invalid directions
-return directionsMap.get(direction.toString()) || false;
-}
-function checkConnection(cell,direction){
-// cell is the cell to be checked, direction is the vector of the connection we are checking
-// e.g check cell x for [0,-1] i.e check if it has a connection to the North
-// returns true or false
-letter = mapDirectionToLetter(direction)
-return cell.options.toString().includes(letter)
-
+  return directionsMap.get(direction.toString()) || false;
 }
 
-function checkAllOptionsForDirection(adjacent_cell,direction) {
-return adjacent_cell.options.every(str => str.includes(mapDirectionToLetter(direction)))
+function checkConnection(cell, direction) {
+  const letter = mapDirectionToLetter(direction);
+  return cell.options.toString().includes(letter);
 }
 
-function adjustPossibilities(collapsedCell,grid_array) {
-/**
- * Returns an updated grid_array with reduced tile options
- *
- * @param {gridSquare} collapsedCell Cell to propogate entropy from.
- * @param {Array} grid_array The Array to propogate entropy through.
- * @return {Array} grid list with updated tileset.
- */
-
-// setup the queue and visited arrays for marking what cells in the grid
-// we need to visit/have visited
-var queue = [];
-var visited = [collapsedCell];
-
-// define the vector directions for NESW in the grid
-directions = [[0,-1],[0,1],[-1,0],[1,0]]
-if (tileset.includes('CITY')){
-  directions = [[0,-1],[0,1],[-1,0],[1,0],[1,-1],[-1,-1],[1,1],[-1,1]]
+function checkAllOptionsForDirection(adjacent_cell, direction) {
+  return adjacent_cell.options.every(str => str.includes(mapDirectionToLetter(direction)));
 }
-const directionstoindex = {
-  '0,-1': [0,4,5],
-  '0,1': [1,6,7],
-  '1,0': [2,4,6],
-  '-1,0': [3,5,7],
-  '1,-1': [4,0,2], // north, northeast, east
-  '-1,-1': [5,0,3], // north, west, northwest
-  '1,1': [6,1,2], // south, southeast, east
-  '-1,1': [7,1,3], //  south, southwest, west
+
+const CITY_DIR_INDEX = {
+  '0,-1': [0, 4, 5],
+  '0,1': [1, 6, 7],
+  '1,0': [2, 4, 6],
+  '-1,0': [3, 5, 7],
+  '1,-1': [4, 0, 2],
+  '-1,-1': [5, 0, 3],
+  '1,1': [6, 1, 2],
+  '-1,1': [7, 1, 3],
 };
 
-// // push the four adjacent cells surrounding the collapsed cell into the queue
-directions.forEach(direction => {
-  result = checkDirection(direction,collapsedCell,grid_array,visited);
-  if(result){
-    queue.push(result)
-  }
-  })
+const CITY_ALL_BIOME_TOKENS = ['G', 'Y', 'LB', 'DB', 'WL', 'WR', 'WU', 'WD'];
 
+function adjustPossibilities(collapsedCell, grid_array) {
+  const queue = [];
+  const visited = [collapsedCell];
+  const directions = dirsFor();
+  const isCity = tileset.includes('CITY');
 
-
-// until we run out of cells in the grid (== checking if the queue isnt empty)
-while (queue.length > 0){
-
-  // remove the first cell from the queue and mark it as current_cell
-  current_cell = queue.shift()
-
-  // if it has entropy 0 (== to only have one tile option skip it)
-  if (current_cell.fixed == true) {
-    continue;
-
-  }
-
-  // collect the four cells adjacent to the current cell and if they are already visited we add them to adjacent_visited
-  // if they aren't visited and not already in the queue we can add them to the queue
-  current_cell.underInspection = true;
-  adjacent_visited = [];
-  adjacent_not_visited = [];
   directions.forEach(direction => {
-    result = checkDirection(direction,current_cell,grid_array,visited,in_visited=identity);
-    if (result){
-      adjacent_visited.push([result,direction])
-    } else {
-      // add current_cells new adjacents to adjacent_not_visited
-      not_visited = checkDirection(direction,current_cell,grid_array,visited);
-      if(not_visited && !inArray(not_visited,queue)){
-        adjacent_not_visited.push(not_visited)
-      }
-    }
-    })
-    var split_adj = [[],[],[],[],[],[],[],[]];
-    var split_cur = [];
+    const result = checkDirection(direction, collapsedCell, grid_array, visited);
+    if (result) queue.push(result);
+  });
 
-  total_indices = [];
-  old_options = JSON.stringify(current_cell.options)
-  adjacent_visited.forEach(pair => {
-    // decompose adjacent_visited into a cell and direction
-    adjacent_cell=pair[0];
-      direction=pair[1];
+  while (queue.length > 0) {
+    const current_cell = queue.shift();
+    if (current_cell.fixed === true) continue;
 
-    if (tileset.includes('CITY')){
-
-
-      cur_indexes =  directionstoindex[direction.toString()]
-      //total_indices.concat(cur_indexes)
-      adj_indexes = directionstoindex[direction.map(function(x) {return x*-1}).toString()]
-      adj_indexes.forEach((adj_index,index) =>{
-        adjacent_cell.options.forEach(option => {
-          if (direction[0]*direction[1]!=0){
-            index = 0;
-          }
-          i=index;
-          if(!split_adj[cur_indexes[index]].includes(option.split('_')[adj_index])) {
-            if(!total_indices.includes(cur_indexes[index])) {
-              total_indices.push(cur_indexes[i])
-            }
-            if(option.split('_')[adj_index]=='WLWR'){
-              split_adj[cur_indexes[index]].push('WL','WR')
-            } else if (option.split('_')[adj_index]=='WUWD') {
-              split_adj[cur_indexes[index]].push('WU','WD')
-            } else {
-              split_adj[cur_indexes[index]].push(option.split('_')[adj_index])
-            }
-
-          }
-        })
-
-      })
-
-
-
-
-
-      // throw('i want a break')
-      // //current_cell.options = current_cell.options.filter(element => !to_remove.includes(element))
-      // current_cell.options = current_cell.options.filter((element,index) => !(to_remove[index]==adjacent_cell.options.length))
-
-    } else {
-
-
-      // if the adjacent cell does not have a connection towards the current cell we remove all tile with a connection towards the adjacent cell
-      if(!checkConnection(adjacent_cell,direction.map(function(x) { return x * -1; }))) {
-        connection = mapDirectionToLetter(direction);
-        current_cell.options = current_cell.options.filter(str => !str.includes(connection))
-      };
-      // check if for every option in the cell to be checked there is always a connector in that direction then we can enforce
-      // that current cell must have a connection in that direction
-      if(checkAllOptionsForDirection(adjacent_cell,direction.map(function(x) { return x * -1; }))) {
-        connection = mapDirectionToLetter(direction);
-        current_cell.options = current_cell.options.filter(str => str.includes(connection))
-      };
-    }
-  })
-  if(tileset.includes('CITY')) {
-    unvisited = [0,1,2,3,4,5,6,7].filter(item=>!total_indices.includes(item))
-    unvisited.forEach((item, i) => {
-      split_adj[item] = ['G','Y','LB','DB','WL','WR','WU','WD',];
-    });
-
-
-    current_cell.options.forEach(option => {
-      var c = 0;
-      split_adj.forEach((bucket,index) => {
-        if(bucket.includes(option.split('_')[index])) {
-          c+=1
+    current_cell.underInspection = true;
+    const adjacent_visited = [];
+    const adjacent_not_visited = [];
+    directions.forEach(direction => {
+      const result = checkDirection(direction, current_cell, grid_array, visited, identity);
+      if (result) {
+        adjacent_visited.push([result, direction]);
+      } else {
+        const not_visited = checkDirection(direction, current_cell, grid_array, visited);
+        if (not_visited && !inArray(not_visited, queue)) {
+          adjacent_not_visited.push(not_visited);
         }
-      })
-      if(c==8) {
-        split_cur.push(option)
-      }
-
-    })
-
-    current_cell.options = split_cur
-  }
-  current_cell.underInspection = false;
-
-  //if the current cell has no options we know this propogation can never work and therefore we throw an error
-  // in order to indicate that backtracking should start
-  if (current_cell.options.length==0){
-    throw new optionsError('No available options',current_cell,grid_array)
-  }
-
-  // add the current cell to visited
-  visited.push(current_cell)
-
-  // if the options post constraint satisfying have changed add the adjacent cells to the queue
-  if (old_options!=JSON.stringify(current_cell.options)) {
-    adjacent_not_visited.forEach((item, i) => {
-      if(!inArray(item,queue)) {
-        queue.push(item)
       }
     });
 
-    //queue = queue.concat(adjacent_not_visited)
+    const split_adj = [[], [], [], [], [], [], [], []];
+    const split_cur = [];
+    const total_indices = [];
+    const old_options = JSON.stringify(current_cell.options);
+
+    adjacent_visited.forEach(pair => {
+      const adjacent_cell = pair[0];
+      const direction = pair[1];
+
+      if (isCity) {
+        const cur_indexes = CITY_DIR_INDEX[direction.toString()];
+        const adj_indexes = CITY_DIR_INDEX[direction.map(x => x * -1).toString()];
+        adj_indexes.forEach((adj_index, index) => {
+          adjacent_cell.options.forEach(option => {
+            let slot = index;
+            if (direction[0] * direction[1] !== 0) slot = 0;
+            const token = option.split('_')[adj_index];
+            if (!split_adj[cur_indexes[slot]].includes(token)) {
+              if (!total_indices.includes(cur_indexes[slot])) {
+                total_indices.push(cur_indexes[slot]);
+              }
+              if (token === 'WLWR') {
+                split_adj[cur_indexes[slot]].push('WL', 'WR');
+              } else if (token === 'WUWD') {
+                split_adj[cur_indexes[slot]].push('WU', 'WD');
+              } else {
+                split_adj[cur_indexes[slot]].push(token);
+              }
+            }
+          });
+        });
+      } else {
+        const reverse = direction.map(x => x * -1);
+        if (!checkConnection(adjacent_cell, reverse)) {
+          const connection = mapDirectionToLetter(direction);
+          current_cell.options = current_cell.options.filter(str => !str.includes(connection));
+        }
+        if (checkAllOptionsForDirection(adjacent_cell, reverse)) {
+          const connection = mapDirectionToLetter(direction);
+          current_cell.options = current_cell.options.filter(str => str.includes(connection));
+        }
+      }
+    });
+
+    if (isCity) {
+      const unvisited = [0, 1, 2, 3, 4, 5, 6, 7].filter(i => !total_indices.includes(i));
+      unvisited.forEach(item => {
+        split_adj[item] = CITY_ALL_BIOME_TOKENS.slice();
+      });
+
+      current_cell.options.forEach(option => {
+        let c = 0;
+        const tokens = option.split('_');
+        for (let index = 0; index < 8; index++) {
+          if (split_adj[index].includes(tokens[index])) c += 1;
+        }
+        if (c === 8) split_cur.push(option);
+      });
+      current_cell.options = split_cur;
+    }
+
+    current_cell.underInspection = false;
+
+    if (current_cell.options.length === 0) {
+      throw new optionsError('No available options', current_cell, grid_array);
+    }
+
+    visited.push(current_cell);
+
+    if (old_options !== JSON.stringify(current_cell.options)) {
+      adjacent_not_visited.forEach(item => {
+        if (!inArray(item, queue)) queue.push(item);
+      });
+    }
   }
-
-
-
-}
-return grid_array
+  return grid_array;
 }
 
-// Function to check if all cells in a grid have been collapsed to a single option
 function finishedCollapse(grid_list) {
-// Initialize a counter to track cells with a single option
-count = 0;
-
-// Iterate through each cell in the grid list
-grid_list.forEach(cell => {
-  // If the cell has only one option, increment the counter
-  if (cell.options.length == 1) {
-    count += 1;
-  }
-});
-filled_count = count;
-// Return true if all cells have a single option (solved grid), false otherwise
-return count == grid_list.length;
+  let count = 0;
+  grid_list.forEach(cell => {
+    if (cell.options.length === 1) count += 1;
+  });
+  filled_count = count;
+  return count === grid_list.length;
 }
 
-// Function to get the position of a random uncollapsed cell from a grid list
 function getRandomUnCollapsedCell(grid_list) {
-// Define possible directions for reference (not directly used in this function)
-directions = [[0, -1], [0, 1], [-1, 0], [1, 0]];
-
-// Filter the grid list to include only cells with at least one option and not fixed
-uncollapsed = grid_list.filter(cell => cell.options.length >= 1 && cell.fixed == false);
-
-// Select a random index within the uncollapsed cells
-index = Math.floor(Math.random() * uncollapsed.length);
-
-// Return the position of the randomly selected uncollapsed cell
-return uncollapsed[index].position;
+  const uncollapsed = grid_list.filter(cell => cell.options.length >= 1 && cell.fixed === false);
+  const index = Math.floor(rng() * uncollapsed.length);
+  return uncollapsed[index].position;
 }
 
+// Run/Restart button — always (re-)initialises a fresh grid and ensures
+// we're in run mode. Pause/Play in wfc-extras handles pause/resume; the
+// top-right ↺ goes back to step 1 for a full teardown. This removes the
+// previous toggle behaviour where the label and state could fall out of
+// phase across runs.
 function changeState() {
-status_bool = !status_bool;
-status_button.html(status_button.html()=='Start' ? 'Reset' : 'Start');
-console.log('%cRESET', 'color: green; background: yellow; font-size: 30px');
-if (status_bool){
-  // if start state
-  grid_list = createGrid(bslider.value(),true);
+  status_bool = true;
+  status_button.html('Restart');
+  grid_list = createGrid(bslider.value(), true);
   backtracking = false;
-  console.log('prob',prob_distr)
-  redraw();
-
-} else{
-  grid_list = [];
   tracking = [];
-  backtracking=false;
-  grid_list = createGrid(bslider.value(),true);
+  old_grids = [];
+  recentBacktrack = null;
+  manualCollapseQueued = null;
+  isPaused = false;
+  const playBtn = document.getElementById('wfc-play');
+  if (playBtn) playBtn.textContent = 'Pause';
   redraw();
 }
-}
+
+// --- Distribution sampling ---------------------------------------------
 
 function createNewNormalisedDistr(options) {
-if(tileset.includes('CITY')){
-  valid_options = [];
-  options.forEach(item => {
-    valid_options.push([find_value(prob_distr,item),item])
-  })
-}
-else {
-  valid_options = prob_distr.filter(item => options.includes(item[1]) )
-}
+  let valid_options;
+  if (tileset.includes('CITY')) {
+    // CITY sliders are biome-level (Grass / Sand / Lagoon / Ocean / Wall) but
+    // the actual tileset has ~100 tiles, multiple per biome. Without the
+    // per-biome divisor below, a cell with 3 grass-dominant options and 1
+    // sand option would weight grass at w_G * 3 vs sand at w_S * 1 — so a
+    // slider set to "Grass 80%" produced ~96% grass in practice. Dividing
+    // each tile's weight by the count of options that share its biome marker
+    // makes the *aggregate* probability of each biome match the slider value.
+    const biomeCounts = {};
+    options.forEach(item => {
+      const key = cityBiomeMarker(item);
+      biomeCounts[key] = (biomeCounts[key] || 0) + 1;
+    });
+    valid_options = options.map(item => {
+      const wv = find_value(prob_distr, item);
+      const key = cityBiomeMarker(item);
+      return [(wv || 0) / biomeCounts[key], item];
+    });
+  } else {
+    valid_options = prob_distr.filter(item => options.includes(item[1]));
+  }
 
-total_prob = valid_options.reduce((sum, item) => sum + item[0], 0)
-new_distr = valid_options.map(item => [item[0] / total_prob, item[1]]);
-return new_distr
+  const total_prob = valid_options.reduce((sum, item) => sum + item[0], 0);
+  return valid_options.map(item => [item[0] / total_prob, item[1]]);
 }
 
 const mostFrequent = arr =>
-Object.entries(
-  arr.reduce((a, v) => {
-    a[v] = a[v] ? a[v] + 1 : 1;
-    return a;
-  }, {})
-).reduce((a, v) => (v[1] >= a[1] ? v : a), [null, 0])[0];
+  Object.entries(
+    arr.reduce((a, v) => {
+      a[v] = a[v] ? a[v] + 1 : 1;
+      return a;
+    }, {}),
+  ).reduce((a, v) => (v[1] >= a[1] ? v : a), [null, 0])[0];
+
+const _biomeMarkerCache = new Map();
+function cityBiomeMarker(name) {
+  const cached = _biomeMarkerCache.get(name);
+  if (cached !== undefined) return cached;
+  let marker;
+  if (name.includes('W')) {
+    marker = 'G_G_WD_WD_G_G_G_G';
+  } else {
+    const m = mostFrequent(name.split('_'));
+    marker = m + '_' + m + '_' + m + '_' + m + '_' + m + '_' + m + '_' + m + '_' + m;
+  }
+  _biomeMarkerCache.set(name, marker);
+  return marker;
+}
 
 function find_value(data, string) {
-if(tileset.includes('CITY')) {
-  if(string.includes('W')){
-    string = 'G_G_WD_WD_G_G_G_G'
-  } else {
-  string = mostFrequent(string.split('_'))
-  string=string+'_'+string+'_'+string+'_'+string+'_'+string+'_'+string+'_'+string+'_'+string
+  let key = string;
+  if (tileset.includes('CITY')) key = cityBiomeMarker(string);
+  for (const [value, string_value] of data) {
+    if (string_value === key) return value;
   }
-}
-for (const [value, string_value] of data) {
-  if (string_value === string) {
-    return value;
-  }
-}
-return null; // Indicate value not found using a clear signal
-
+  return null;
 }
 
 function leastEntropy(grid_list) {
-entropy_vals=new Array(grid_list.length).fill(0)
-grid_list.forEach((tile,index) =>{
-  if(tile.options.length==1) {
-    entropy_vals[index]=999
-  } else{
-    entropy_vals[index] = -1*tile.options.reduce((sum, item) => sum +find_value(prob_distr,item)*Math.log(find_value(prob_distr,item)), 0)
-  }
-
-})
-return grid_list[entropy_vals.indexOf(Math.min.apply(null,entropy_vals))]
+  const entropy_vals = new Array(grid_list.length).fill(0);
+  grid_list.forEach((tile, index) => {
+    if (tile.options.length === 1) {
+      entropy_vals[index] = 999;
+    } else {
+      entropy_vals[index] = -1 * tile.options.reduce((sum, item) => {
+        const p = find_value(prob_distr, item);
+        return sum + p * Math.log(p);
+      }, 0);
+    }
+  });
+  return grid_list[entropy_vals.indexOf(Math.min.apply(null, entropy_vals))];
 }
 
-// Function to reset the "fixed" state of neighboring cells
 function reset_neighbours(bad_cell, grid_array) {
-// Initialize an empty list to store adjacent cells
-adjacent = [];
-
-// Define possible directions to check
-directions = [[0, -1], [0, 1], [-1, 0], [1, 0]];
-if (tileset.includes('CITY')){
-  directions = [[0,-1],[0,1],[-1,0],[1,0],[1,-1],[-1,-1],[1,1],[-1,1]]
+  const directions = dirsFor();
+  directions.forEach(direction => {
+    const result = checkDirection(direction, bad_cell, grid_array, [new gridSquare([-100, -100], 'FG')]);
+    if (result) {
+      const found_cell = findByPos(grid_array, result.position);
+      if (found_cell) found_cell.fixed = false;
+    }
+  });
+  return grid_array;
 }
-
-// Iterate through each direction:
-directions.forEach(direction => {
-  // Check for a valid neighboring cell in that direction
-  result = checkDirection(direction, bad_cell, grid_array, [new gridSquare([-100, -100], 'FG')]);
-
-  // If a valid neighbor is found:
-  if (result) {
-    // Retrieve the neighbor cell from the grid array
-    found_cell = grid_array[grid_array.findIndex(cell => JSON.stringify(cell.position) == JSON.stringify(result.position))];
-
-    // Unfix the neighbor cell (make it changeable again)
-    found_cell.fixed = false;
-  }
-});
-
-// Return the updated grid array
-return grid_array;
-}
-
-
 
 function sampleOptionsFromDistribution(options) {
-new_distr = createNewNormalisedDistr(options)
-rand_sample = Math.random()
-var cumulative_sum = 0;
-for (item of new_distr) {
-  prob = item[0];
-  tile = item[1];
-  cumulative_sum += prob
-  if (cumulative_sum >= rand_sample) {
-    return tile
+  const new_distr = createNewNormalisedDistr(options);
+  const rand_sample = rng();
+  let cumulative_sum = 0;
+  let tile;
+  for (const item of new_distr) {
+    tile = item[1];
+    cumulative_sum += item[0];
+    if (cumulative_sum >= rand_sample) return tile;
   }
-
-}
-return tile
+  return tile;
 }
 
+// --- Run-extras UI (speed / step / seed / share / save / popover) ------
+
+function ensureRunControls() {
+  const host = document.getElementById('wfc-controls');
+  if (!host || document.getElementById('wfc-extras')) return;
+
+  const extras = document.createElement('div');
+  extras.id = 'wfc-extras';
+  extras.className = 'wfc-extras';
+  extras.innerHTML = `
+    <div class="wfc-row">
+      <button id="wfc-play" type="button" title="Pause / resume the run">Pause</button>
+      <button id="wfc-step" type="button" title="Advance one collapse step (pauses the auto-loop)">Step ▶|</button>
+      <label class="wfc-label" for="wfc-speed">Speed</label>
+      <input id="wfc-speed" type="range" min="0" max="500" step="10" value="0" />
+      <span id="wfc-speed-val" class="wfc-num">fast</span>
+    </div>
+    <div class="wfc-row">
+      <label class="wfc-label" for="wfc-seed">Seed</label>
+      <input id="wfc-seed" type="number" min="0" max="4294967295" />
+      <button id="wfc-share" type="button" title="Copy a URL that reproduces this run">Share</button>
+      <button id="wfc-save" type="button" title="Download the canvas as PNG">Save PNG</button>
+    </div>
+  `;
+  host.appendChild(extras);
+
+  const seedInput = extras.querySelector('#wfc-seed');
+  seedInput.value = String(rngSeed);
+  seedInput.addEventListener('change', () => {
+    const n = parseInt(seedInput.value, 10);
+    if (Number.isFinite(n)) {
+      reseed(n);
+      updateShareURL();
+    }
+  });
+
+  const playBtn = extras.querySelector('#wfc-play');
+  playBtn.addEventListener('click', () => {
+    isPaused = !isPaused;
+    playBtn.textContent = isPaused ? 'Play' : 'Pause';
+  });
+
+  extras.querySelector('#wfc-step').addEventListener('click', () => {
+    ensureGridReady();
+    forceStepOnce = true;
+    if (!status_bool && !backtracking) status_bool = true;
+    // Stepping implies pausing the auto-loop — otherwise the next frame
+    // immediately advances again and the "step" is invisible.
+    isPaused = true;
+    playBtn.textContent = 'Play';
+  });
+
+  const speedInput = extras.querySelector('#wfc-speed');
+  const speedReadout = extras.querySelector('#wfc-speed-val');
+  speedInput.addEventListener('input', () => {
+    stepIntervalMs = parseInt(speedInput.value, 10) || 0;
+    speedReadout.textContent = stepIntervalMs === 0 ? 'fast' : stepIntervalMs + 'ms';
+  });
+
+  extras.querySelector('#wfc-share').addEventListener('click', async () => {
+    updateShareURL();
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      flashButton(extras.querySelector('#wfc-share'), 'Copied!');
+    } catch (_) {
+      flashButton(extras.querySelector('#wfc-share'), 'URL updated');
+    }
+  });
+
+  extras.querySelector('#wfc-save').addEventListener('click', () => {
+    try {
+      saveCanvas('wfc-result-' + rngSeed, 'png');
+    } catch (e) {
+      console.warn('[wfc] saveCanvas failed', e);
+    }
+  });
+}
+
+function flashButton(btn, msg) {
+  const original = btn.textContent;
+  btn.textContent = msg;
+  btn.disabled = true;
+  setTimeout(() => { btn.textContent = original; btn.disabled = false; }, 1100);
+}
+
+// --- Click-to-collapse popover -----------------------------------------
+
+let popoverEl = null;
+
+function closePopover() {
+  if (popoverEl) {
+    popoverEl.remove();
+    popoverEl = null;
+  }
+}
+
+// Mobile width threshold — popovers below this collapse to a full-width
+// bottom sheet via CSS so we skip per-pixel positioning. Keep in sync
+// with the @media rule in wfc.css.
+const MOBILE_MAX_WIDTH = 640;
+
+function openPopoverForCell(cell, screenX, screenY) {
+  closePopover();
+  const host = document.getElementById('wfc-canvas');
+  if (!host) return;
+
+  const pop = document.createElement('div');
+  pop.className = 'wfc-popover';
+  // Hide during measure so the user doesn't see the popover jump from
+  // the click point to its final clamped position.
+  pop.style.visibility = 'hidden';
+  pop.style.left = '0px';
+  pop.style.top = '0px';
+
+  const header = document.createElement('div');
+  header.className = 'wfc-popover-title';
+  header.textContent = `Collapse (${cell.position[0]}, ${cell.position[1]}) — ${cell.options.length} options`;
+  pop.appendChild(header);
+
+  const grid = document.createElement('div');
+  grid.className = 'wfc-popover-grid';
+  cell.options.forEach(opt => {
+    const img = document.createElement('img');
+    img.src = thumbSrcForOption(opt);
+    img.alt = opt;
+    img.title = opt;
+    img.addEventListener('click', e => {
+      // Stop bubbling so the parent #wfc-canvas click listener doesn't
+      // immediately open a fresh popover for whatever cell sits under
+      // the thumbnail's screen position.
+      e.stopPropagation();
+      manualCollapseQueued = { cell, tile: opt };
+      closePopover();
+    });
+    grid.appendChild(img);
+  });
+  pop.appendChild(grid);
+
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'wfc-popover-close';
+  close.textContent = '✕';
+  close.addEventListener('click', e => {
+    e.stopPropagation();
+    closePopover();
+  });
+  pop.appendChild(close);
+
+  host.appendChild(pop);
+  popoverEl = pop;
+
+  // Clamp to the canvas host bounds so the popover doesn't drift off
+  // the right/bottom edges when the click was near a corner. On mobile
+  // (<=640px) the popover becomes a full-width bottom sheet via CSS,
+  // so we leave its position alone and let the stylesheet drive it.
+  const isMobile = window.matchMedia(`(max-width: ${MOBILE_MAX_WIDTH}px)`).matches;
+  if (!isMobile) {
+    const hostRect = host.getBoundingClientRect();
+    const popW = pop.offsetWidth;
+    const popH = pop.offsetHeight;
+    let left = screenX;
+    let top = screenY;
+    if (left + popW + 8 > hostRect.width) left = hostRect.width - popW - 8;
+    if (top + popH + 8 > hostRect.height) top = hostRect.height - popH - 8;
+    left = Math.max(8, left);
+    top = Math.max(8, top);
+    pop.style.left = left + 'px';
+    pop.style.top = top + 'px';
+  } else {
+    // Mobile bottom sheet — let CSS handle position; clear the inline
+    // left/top so they don't override the stylesheet.
+    pop.style.left = '';
+    pop.style.top = '';
+  }
+  pop.style.visibility = '';
+}
+
+function thumbSrcForOption(name) {
+  // Walk the manifest for a tile file matching the active tileset whose
+  // basename (sans extension) equals `name`. Manifest paths are absolute
+  // (/posts/WFC/...), which is what the browser wants.
+  for (const src of manifest) {
+    if (!src.includes(tileset)) continue;
+    const base = src.split('/').pop().split('.')[0];
+    if (base === name) return src;
+  }
+  return '';
+}
+
+// Populate grid_list lazily so the new entry points (Step button,
+// canvas click) work even before the user has touched the legacy p5
+// "start" button. Idempotent — only runs if the grid is empty.
+function ensureGridReady() {
+  if (grid_list.length === 0 && bslider) {
+    grid_list = createGrid(bslider.value(), true);
+    tracking = [];
+    old_grids = [];
+    backtracking = false;
+    recentBacktrack = null;
+  }
+}
+
+function canvasClickHandler(evt) {
+  ensureGridReady();
+  if (!grid_list.length) return;
+  const cnvEl = document.querySelector('#wfc-canvas canvas');
+  if (!cnvEl) return;
+  const r = cnvEl.getBoundingClientRect();
+  const localX = evt.clientX - r.left;
+  const localY = evt.clientY - r.top;
+  if (localX < 0 || localY < 0 || localX > r.width || localY > r.height) return;
+
+  const grid_size = Math.sqrt(grid_list.length);
+  // Canvas is scaled via CSS to host width — map back to grid coords.
+  const cx = Math.floor((localX / r.width) * grid_size);
+  const cy = Math.floor((localY / r.height) * grid_size);
+  const cell = findByPos(grid_list, [cx, cy]);
+  if (!cell) return;
+  if (cell.options.length <= 1) return; // nothing to choose
+
+  // Pause so the popover sticks around while the reader decides.
+  isPaused = true;
+  const playBtn = document.getElementById('wfc-play');
+  if (playBtn) playBtn.textContent = 'Play';
+
+  // Position popover near the click, clamped to the host.
+  const host = document.getElementById('wfc-canvas');
+  const hostRect = host.getBoundingClientRect();
+  let px = evt.clientX - hostRect.left + 12;
+  let py = evt.clientY - hostRect.top + 12;
+  openPopoverForCell(cell, px, py);
+}
+
+// --- p5 hooks -----------------------------------------------------------
+
+// Build the primary-controls wrapper inside #wfc-controls so the
+// grid-size label, slider, readout, and Run button share a stable
+// parent. Without this, the p5-created bslider migrates to the end of
+// #wfc-controls on every startWFC (parent() always appends), which on
+// the second run leaves it sitting *after* #wfc-extras.
+function ensurePrimaryControlsDom() {
+  const ctrl = document.getElementById('wfc-controls');
+  if (!ctrl || document.getElementById('wfc-primary')) return;
+  const primary = document.createElement('div');
+  primary.id = 'wfc-primary';
+  primary.className = 'wfc-primary';
+  const label = document.createElement('label');
+  label.className = 'wfc-label';
+  label.textContent = 'Grid size';
+  primary.appendChild(label);
+  ctrl.appendChild(primary);
+}
 
 function setup() {
-//frameRate(10);
-svgFilenames.forEach(filename => {
-  gridimages[filename.split('/').at(-1).split('.')[0]] = loadImage(filename);
-    });
+  svgFilenames.forEach(filename => {
+    gridimages[filename.split('/').at(-1).split('.')[0]] = loadImage(filename);
+  });
 
-computeCanvasSize();
-var cnv = createCanvas(cnv_w, cnv_h);
-cnv.parent("wfc-canvas");
+  computeCanvasSize();
+  const cnv = createCanvas(cnv_w, cnv_h);
+  cnv.parent('wfc-canvas');
 
-bslider = createSlider(1, slider_max, 2);
-bslider.parent("wfc-controls")
+  ensurePrimaryControlsDom();
 
-slider_text = createP(bslider.value())
-slider_text.parent("wfc-controls")
+  bslider = createSlider(1, slider_max, 2);
+  bslider.parent('wfc-primary');
 
-status_button = createButton("start");
-status_button.parent("wfc-controls")
-status_button.mousePressed(changeState)
+  slider_text = createP(bslider.value());
+  slider_text.parent('wfc-primary');
+
+  status_button = createButton('Run');
+  status_button.parent('wfc-primary');
+  status_button.mousePressed(changeState);
+  if (status_button.elt) status_button.elt.classList.add('wfc-run-button');
+
+  bindCanvasClickHandler();
+}
+
+// Bind click-to-collapse via the #wfc-canvas host (clicks on the canvas
+// child bubble up) so we don't race p5's canvas-attachment order. The
+// _wfcClickBound flag keeps this idempotent across multiple invocations.
+function bindCanvasClickHandler() {
+  const host = document.getElementById('wfc-canvas');
+  if (!host || host._wfcClickBound) return;
+  host.addEventListener('click', evt => {
+    // Ignore clicks on the popover itself.
+    if (popoverEl && popoverEl.contains(evt.target)) return;
+    canvasClickHandler(evt);
+  });
+  host._wfcClickBound = true;
+}
+
+let neighbour;
+let forbacktrack;
+let old_grid_list;
+let toretry;
+let switch_bool;
+
+// Pick & sample the next cell to collapse. Pulled out of draw() so step
+// throttling + the manual-collapse path share the same pipeline.
+function pickAndCollapseOne() {
+  // Manual override from a popover click wins over the heuristic pick.
+  if (manualCollapseQueued) {
+    neighbour = manualCollapseQueued.cell;
+    const tile = manualCollapseQueued.tile;
+    forbacktrack = new trackingObj(neighbour, neighbour.options);
+    neighbour.options = [tile];
+    forbacktrack.indexes.push(tile);
+    forbacktrack.options = forbacktrack.options.filter(t => t !== tile);
+    manualCollapseQueued = null;
+    backtracking = true;
+    status_bool = false;
+    return;
+  }
+  if (finishedCollapse(grid_list)) return;
+
+  switch_bool = true;
+  if (switch_bool && filled_count < 0.2 * grid_list.length) {
+    const neighbour_pos = getRandomUnCollapsedCell(grid_list);
+    neighbour = findByPos(grid_list, neighbour_pos);
+  } else {
+    neighbour = leastEntropy(grid_list);
+  }
+  const collapsed_tile = sampleOptionsFromDistribution(neighbour.options);
+  forbacktrack = new trackingObj(neighbour, neighbour.options);
+  neighbour.options = [collapsed_tile];
+  forbacktrack.indexes.push(collapsed_tile);
+  forbacktrack.options = forbacktrack.options.filter(t => t !== collapsed_tile);
+  backtracking = true;
+  status_bool = false;
 }
 
 function draw() {
-  // Track viewport size (used by some unrelated formulas) and recompute the
-  // canvas size off its container so the demo stays inside the post body.
+  try {
+    drawImpl();
+  } catch (e) {
+    // Last-resort: an unexpected throw inside drawImpl must NOT kill
+    // p5's draw loop, otherwise the canvas freezes and the Restart
+    // button has nothing to render into. Wipe the run state and let
+    // the next frame start fresh.
+    console.error('[wfc] draw error, auto-recovering', e);
+    backtracking = false;
+    status_bool = false;
+    tracking = [];
+    old_grids = [];
+    recentBacktrack = null;
+    manualCollapseQueued = null;
+    grid_list = bslider ? createGrid(bslider.value(), true) : [];
+  }
+}
+
+function drawImpl() {
   w = window.innerWidth;
   h = window.innerHeight;
   computeCanvasSize();
   resizeCanvas(cnv_w, cnv_h);
   background(220);
-  if(status_bool){
-    switch_bool = true;
-    if (finishedCollapse(grid_list)==false) {
-      //get neighbour to a collapsed cell
 
-      if (switch_bool && filled_count<0.2*grid_list.length) {
-        //select randomly
-        neighbour_pos = getRandomUnCollapsedCell(grid_list);
-        neighbour = grid_list[grid_list.findIndex(cell =>JSON.stringify(cell.position)==JSON.stringify(neighbour_pos))];
-        switch_bool = !switch_bool;
-      } else {
-        //least entropy heuristic
-        neighbour = leastEntropy(grid_list);
-        switch_bool = !switch_bool;
-      }
-      // neighbour = leastEntropy(grid_list);
-      //collapse it
-      collapsed_tile = sampleOptionsFromDistribution(neighbour.options);
-      forbacktrack = new trackingObj(neighbour,neighbour.options);
-      neighbour.options = [collapsed_tile];
-      forbacktrack.indexes.push(collapsed_tile);
-      forbacktrack.options = forbacktrack.options.filter(tile => JSON.stringify(tile) != JSON.stringify(collapsed_tile))
-      backtracking = true;
-      status_bool = !status_bool
-  }
+  const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+  const allowAdvance = forceStepOnce ||
+    (!isPaused && (stepIntervalMs === 0 || now - lastStepTime >= stepIntervalMs));
 
-  }
-  if (backtracking) {
-    try {
-      // try adjust probabilities
-      old_grid_list = JSON.parse(JSON.stringify(grid_list));
-      grid_list = adjustPossibilities(neighbour,grid_list);
+  // Manual collapse from the popover always advances, regardless of pause.
+  const hasManual = manualCollapseQueued !== null;
+  const advanceThisFrame = allowAdvance || hasManual;
 
-      // if it doesnt error add it to tracking/oldgrids, fix the cell
-      // and end backtracking and try to fix another cell
-      tracking.push(forbacktrack);
-      old_grids.push(old_grid_list)
-      neighbour.fixed = true;
-      backtracking = false;
-      status_bool = true;
-    } catch(error) {
-      // Log error details
-      console.error(`Error: ${error.name}: ${error.message}`);
-      console.error(error.stack);
-      // console.log(neighbour.position, neighbour.options, tracking.length);
-      // Handle a specific error type (optionsError)
-      if (error instanceof optionsError) {
-        // Restore previous grid state
-        grid_list = old_grid_list;
-        // Highlight the problematic cell
-        grid_list[grid_list.findIndex(cell => JSON.stringify(cell.position) == JSON.stringify(error.broken_cell.position))].underInspection = true;
+  if (advanceThisFrame) {
+    if (status_bool || hasManual) {
+      pickAndCollapseOne();
+    }
 
-        // Initiate backtracking
-        backtracking = true;
-        var solvable=true;
+    if (backtracking) {
+      let solvable = true;
+      try {
+        old_grid_list = cloneGrid(grid_list);
+        grid_list = adjustPossibilities(neighbour, grid_list);
 
-        // Find a cell with remaining options to retry
-        if(tracking.length == 0) {
-          solvable=false;
-        } else {
-          while (true) {
+        tracking.push(forbacktrack);
+        old_grids.push(old_grid_list);
+        neighbour.fixed = true;
+        backtracking = false;
+        status_bool = true;
+      } catch (error) {
+        if (error instanceof optionsError) {
+          // Surface the failed propagation as a red flash overlay.
+          recentBacktrack = {
+            position: error.broken_cell.position.slice(),
+            framesLeft: BACKTRACK_FLASH_FRAMES,
+          };
+          grid_list = old_grid_list;
+          const broken = findByPos(grid_list, error.broken_cell.position);
+          if (broken) broken.underInspection = true;
 
-            toretry = tracking.pop();
-            // console.log('h1',toretry)
-            // console.log('here',toretry.options)
-            if (toretry.options.length > 0) {
-              break;
-            } else if (tracking.length > 0) {
-              // move back another grid in history if a cell has no available options left to try
-              grid_list = old_grids.pop();
-              renderGrid(grid_list);
-            } else {
-              // Grid is unsolvable
-              //grid_list = [];
-              solvable=false;
-              break;
+          backtracking = true;
+
+          // Drain tracking + old_grids together. On big CITY grids (7+)
+          // it's easy to pop more than we pushed during nested backtracks,
+          // and an empty .pop() returns undefined — which then propagates
+          // into reset_neighbours → checkDirection.some(...) and throws
+          // a secondary error that escapes this catch, killing p5's draw
+          // loop. Guard every pop and bail to the auto-restart branch if
+          // history is exhausted.
+          if (tracking.length === 0) {
+            solvable = false;
+          } else {
+            while (true) {
+              toretry = tracking.pop();
+              if (!toretry) { solvable = false; break; }
+              if (toretry.options.length > 0) {
+                break;
+              } else if (tracking.length > 0 && old_grids.length > 0) {
+                const snapshot = old_grids.pop();
+                if (!snapshot) { solvable = false; break; }
+                grid_list = snapshot;
+                renderGrid(grid_list);
+              } else {
+                solvable = false;
+                break;
+              }
             }
           }
+
+          if (solvable) {
+            const snapshot = old_grids.pop();
+            if (!snapshot) {
+              solvable = false;
+            } else {
+              grid_list = snapshot;
+              grid_list = reset_neighbours(error.broken_cell, grid_list);
+
+              const new_tile = sampleOptionsFromDistribution(toretry.options);
+              toretry.options = toretry.options.filter(element => !element.includes(new_tile));
+              toretry.indexes.push(new_tile);
+              tracking.push(toretry);
+
+              const newNeighbour = findByPos(grid_list, toretry.gridSquare.position);
+              if (newNeighbour) {
+                neighbour = newNeighbour;
+                neighbour.options = [new_tile];
+              } else {
+                solvable = false;
+              }
+            }
+          }
+          if (!solvable) {
+            // Out of backtracking options — wipe history and start a
+            // fresh grid so the run can keep making forward progress.
+            old_grids = [];
+            tracking = [];
+            backtracking = false;
+            grid_list = bslider ? createGrid(bslider.value(), true) : [];
+          }
+        } else {
+          // Unknown error — log and continue rendering.
+          console.error('[wfc]', error);
         }
       }
-      if(solvable) {
-      // Restore grid state from history
-      grid_list = old_grids.pop();
-      grid_list = reset_neighbours(error.broken_cell, grid_list);  // Unfix affected neighbors
-
-      // Prepare for retry
-      new_tile = sampleOptionsFromDistribution(toretry.options) // Get a new option to try
-      // console.log(new_tile)
-      toretry.options = toretry.options.filter(element => !element.includes(new_tile))
-      toretry.indexes.push(new_tile);    // Track the attempted option
-      tracking.push(toretry);            // Add back to tracking for potential future backtracking
-
-      // Update the grid with the new option
-      neighbour = grid_list[grid_list.findIndex(cell => JSON.stringify(cell.position) == JSON.stringify(toretry.gridSquare.position))];
-      neighbour.options = [new_tile];
-
-      console.log('%cDIDABACKTRACK', 'color: red; background: white; font-size: 30px');
-      }
-      else {
-        old_grids=[];
-        grid_list = [];
-        tracking = [];
-        grid_list = createGrid(bslider.value())
-      }
     }
+
+    if (allowAdvance) lastStepTime = now;
+    forceStepOnce = false;
   }
 
-  renderGrid(grid_list)
-
-  //actually do stuff
-  slider_text.html(bslider.value())
+  renderGrid(grid_list);
+  if (slider_text) slider_text.html(bslider.value());
 }
 
-// Deterministic p5 bootstrap. p5's global mode auto-scans `window.setup`
-// exactly once on its own DOMContentLoaded handler — if wfc.js hasn't
-// executed yet, p5 finds nothing and silently no-ops, leaving STARTWFC's
-// `createSlider(...)` to throw later. Instead of relying on script load
-// order, we explicitly `new p5()` here once p5 is available, which forces
-// a re-scan of window.setup/draw at a known-good time. The `__wfcReady`
-// flag lets the e2e tests wait on a single deterministic signal rather
-// than racing through multiple global-existence checks.
+// Deterministic p5 bootstrap. See the long comment above the IIFE in the
+// original file — order-sensitive global-mode setup.
 (function bootstrapP5() {
   if (typeof window === 'undefined') return;
-  // Bound the polling loop so a missing p5 CDN doesn't spin forever — fail
-  // loudly after ~10s (200 × 50ms) so the cause is visible in DevTools.
-  var MAX_TRIES = 200;
-  var tries = 0;
+  const MAX_TRIES = 200;
+  let tries = 0;
   function tick() {
     if (typeof window.p5 === 'function') {
       if (!document.querySelector('#wfc-canvas canvas')) {
         new window.p5();
       }
+      // Expose the seed so the e2e tests can assert determinism across runs.
+      window.__wfcRngSeed = rngSeed;
       window.__wfcReady = true;
       return;
     }

--- a/public/WFC_code/wfc_flow.js
+++ b/public/WFC_code/wfc_flow.js
@@ -104,6 +104,18 @@ function setupProbGraph(folder) {
   tileselect.style.display = 'none';
   prob_graph.style.display = 'block';
   tileset = folder;
+  // Reveal the help panel from step 2 onwards so first-time users see
+  // all the controls they're about to encounter in step 3.
+  var help = document.getElementById('wfc-help');
+  if (help) {
+    help.removeAttribute('hidden');
+    // Default to open on first reveal, but respect the user's collapse
+    // state on subsequent reveals (e.g. via Reset → pick again).
+    if (!help.dataset.touched) {
+      help.open = true;
+      help.dataset.touched = '1';
+    }
+  }
 
   var biomes = folder.includes('CITY') ? ['Grass', 'Sand', 'Lagoon', 'Ocean', 'Wall'] : null;
   var n = folder_subset.length;

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -200,4 +200,68 @@ test.describe('Mobile · Pixel 5', () => {
     await expect.poll(() => page.evaluate(() => window.scrollY), { timeout: 3000 }).toBeLessThanOrEqual(1);
     await expect(page.getByLabel('Breadcrumb')).toBeInViewport();
   });
+
+  // WFC widget — mobile click-to-collapse should turn the popover into a
+  // bottom sheet anchored to the viewport, not the desktop floating
+  // panel that can drift off the canvas on small screens.
+  test('WFC click-to-collapse popover is a bottom sheet on mobile @multistep', async ({ page }) => {
+    await page.goto('/posts/wfc?autostart=0');
+    await page.waitForFunction(
+      () => (window as unknown as { __wfcReady?: boolean }).__wfcReady === true,
+      { timeout: 20_000 },
+    );
+    // Pick the first available tileset card and start the canvas step.
+    await page.locator('#tileselect .image-container button').first().click();
+    await expect(page.locator('#STARTWFC')).toBeVisible();
+    await page.locator('#STARTWFC').click();
+    const canvas = page.locator('#wfc-canvas canvas');
+    await expect(canvas).toBeVisible({ timeout: 15_000 });
+
+    // Help panel should be visible on mobile too.
+    await expect(page.locator('#wfc-help')).toBeVisible();
+
+    // Tap a cell to open the popover.
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error('canvas box missing');
+    await page.tap('#wfc-canvas canvas', { position: { x: box.width / 2, y: box.height / 2 } });
+    const popover = page.locator('.wfc-popover');
+    await expect(popover).toBeVisible({ timeout: 5_000 });
+
+    // On the Pixel 5 viewport (393×851), CSS makes the popover a bottom
+    // sheet: full-width, anchored to the bottom of the viewport.
+    const layout = await page.evaluate(() => {
+      const pop = document.querySelector('.wfc-popover');
+      if (!pop) return null;
+      const r = pop.getBoundingClientRect();
+      return {
+        left: r.left,
+        right: r.right,
+        bottom: r.bottom,
+        width: r.width,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      };
+    });
+    if (!layout) throw new Error('popover layout read failed');
+    // Spans the full viewport width (within 1px).
+    expect(layout.width).toBeGreaterThanOrEqual(layout.viewportWidth - 1);
+    expect(layout.left).toBeLessThanOrEqual(1);
+    // Anchored at (or beyond, due to safe-area padding) the viewport
+    // bottom — `bottom` should equal viewportHeight, not float above.
+    expect(layout.bottom).toBeGreaterThanOrEqual(layout.viewportHeight - 1);
+  });
+
+  test('WFC widget renders without horizontal overflow on mobile', async ({ page }) => {
+    await page.goto('/posts/wfc?autostart=0');
+    await page.waitForFunction(
+      () => (window as unknown as { __wfcReady?: boolean }).__wfcReady === true,
+      { timeout: 20_000 },
+    );
+    await page.locator('#tileselect .image-container button').first().click();
+    await page.locator('#STARTWFC').click();
+    await expect(page.locator('#wfc-canvas canvas')).toBeVisible({ timeout: 15_000 });
+    // Both the help panel and the run-extras row are revealed by now;
+    // none of them should push the page wider than the viewport.
+    expect(await horizontalOverflowPx(page)).toBeLessThanOrEqual(1);
+  });
 });

--- a/tests/e2e/wfc.spec.ts
+++ b/tests/e2e/wfc.spec.ts
@@ -26,6 +26,10 @@ async function waitForP5Ready(page: Page) {
 // See tests/e2e/multistep.spec.ts header for the full rule.
 
 const WFC_URL = '/posts/wfc';
+// Tests that need a frozen post-STARTWFC state (so the draw loop doesn't
+// mutate grid_list / consume the RNG underneath the assertions) use
+// `?autostart=0` to opt out of the auto-run on STARTWFC click.
+const WFC_URL_FROZEN = '/posts/wfc?autostart=0';
 
 // Modest per-test timeout bump for cold Turbopack compiles of /posts/wfc.
 test.describe.configure({ timeout: 60_000 });
@@ -44,6 +48,10 @@ test.describe('WFC interactive widget', () => {
 
   test('selecting a tileset reveals the probability distribution editor @multistep', async ({ page }) => {
     await page.goto(WFC_URL);
+    // Help panel is hidden in step 1; first user action (picking a tileset)
+    // is what reveals it.
+    await expect(page.locator('#wfc-help')).toBeHidden();
+
     const firstSelect = page.locator('#tileselect .image-container button').first();
     await expect(firstSelect).toBeVisible({ timeout: 15_000 });
     await firstSelect.click();
@@ -54,6 +62,12 @@ test.describe('WFC interactive widget', () => {
     const startBtn = page.locator('#STARTWFC');
     await expect(startBtn).toBeVisible();
     await expect(startBtn).toHaveText(/start collapse/i);
+
+    // Help panel is now revealed and open by default on first show.
+    const help = page.locator('#wfc-help');
+    await expect(help).toBeVisible();
+    await expect(help).toHaveAttribute('open', '');
+    await expect(help.locator('.wfc-help-list li').first()).toBeVisible();
   });
 
   test('running the collapse renders a p5 canvas @multistep', async ({ page }) => {
@@ -93,5 +107,467 @@ test.describe('WFC interactive widget', () => {
     await expect(page.locator('#wfc-container')).toBeHidden();
     // Reset removes the STARTWFC button.
     await expect(page.locator('#STARTWFC')).toHaveCount(0);
+  });
+
+  // Regression for issue #16: "Probability Distr in WFC demo actually being
+  // respected in the WFC". sampleOptionsFromDistribution is the one-shot the
+  // collapse loop uses to pick a tile from a cell's remaining options. We
+  // call it directly with crafted prob_distr/tileset state and verify the
+  // empirical frequencies match the weights. For CITY we check the
+  // *aggregate* biome probability (per-biome divisor in
+  // createNewNormalisedDistr — without it, biomes with more dominant tiles
+  // were over-represented vs the slider value).
+  test('sampleOptionsFromDistribution honors prob_distr weights @multistep', async ({ page }) => {
+    await page.goto(WFC_URL_FROZEN);
+    await waitForP5Ready(page);
+    // Pick the REDGRID_EASY card by label so we don't depend on folder order.
+    const redgridCard = page
+      .locator('#tileselect .image-container')
+      .filter({ hasText: /REDGRID_EASY/i });
+    await expect(redgridCard).toBeVisible({ timeout: 15_000 });
+    await redgridCard.locator('button').click();
+    await expect(page.locator('#prob_graph')).toBeVisible();
+    // STARTWFC fires createGrid(), which populates window.global_options. We
+    // need it populated before invoking sampleOptionsFromDistribution.
+    await page.locator('#STARTWFC').click();
+    await expect(page.locator('#wfc-canvas canvas')).toBeVisible({ timeout: 15_000 });
+
+    // REDGRID: per-tile sliders. Bias DR heavily and check frequencies.
+    const redgridResult = await page.evaluate(() => {
+      // Top-level `var` declarations in wfc.js / wfc_flow.js become window
+      // properties in non-module scripts. Cast through unknown to satisfy TS.
+      const w = window as unknown as {
+        global_options: string[];
+        prob_distr: Array<[number, string]>;
+        sampleOptionsFromDistribution: (opts: string[]) => string;
+      };
+      const opts = [...w.global_options];
+      const weights: Record<string, number> = {};
+      const target = 'DR';
+      const targetW = 0.6;
+      const rest = (1 - targetW) / (opts.length - 1);
+      opts.forEach(o => (weights[o] = o === target ? targetW : rest));
+      w.prob_distr = opts.map(o => [weights[o], o]);
+      const counts: Record<string, number> = {};
+      opts.forEach(o => (counts[o] = 0));
+      const N = 8000;
+      for (let i = 0; i < N; i++) {
+        const t = w.sampleOptionsFromDistribution(opts);
+        counts[t] = (counts[t] || 0) + 1;
+      }
+      return { N, counts, weights, opts };
+    });
+    // Sanity: DR is in the option set the test ran against.
+    expect(redgridResult.opts).toContain('DR');
+    // Empirical frequency for each tile is within ±0.03 of weight (8000
+    // samples gives stderr ~0.005 for p≈0.6; ±0.03 is ~6σ — virtually
+    // never flakes).
+    for (const o of redgridResult.opts) {
+      const empirical = redgridResult.counts[o] / redgridResult.N;
+      expect(Math.abs(empirical - redgridResult.weights[o])).toBeLessThan(0.03);
+    }
+
+    // Now CITY: aggregate biome probability should match the slider.
+    await page.locator('#resetButton').click();
+    const cityCard = page
+      .locator('#tileselect .image-container')
+      .filter({ hasText: /CITY/i });
+    await expect(cityCard).toBeVisible();
+    await cityCard.locator('button').click();
+    await expect(page.locator('#prob_graph')).toBeVisible();
+    await page.locator('#STARTWFC').click();
+    await expect(page.locator('#wfc-canvas canvas')).toBeVisible({ timeout: 15_000 });
+
+    const cityResult = await page.evaluate(() => {
+      const w = window as unknown as {
+        global_options: string[];
+        prob_distr: Array<[number, string]>;
+        sampleOptionsFromDistribution: (opts: string[]) => string;
+      };
+      // Inline biome-marker derivation so the assertion doesn't depend on
+      // the (private) helper being exposed on window.
+      const mostFreq = (arr: string[]) =>
+        Object.entries(
+          arr.reduce<Record<string, number>>((a, v) => {
+            a[v] = (a[v] || 0) + 1;
+            return a;
+          }, {}),
+        ).reduce((a, v) => (v[1] >= a[1] ? v : a), ['', 0])[0];
+      const biome = (name: string) => {
+        if (name.includes('W')) return 'W';
+        return mostFreq(name.split('_'));
+      };
+      const cityKeys = [
+        'G_G_G_G_G_G_G_G',
+        'Y_Y_Y_Y_Y_Y_Y_Y',
+        'LB_LB_LB_LB_LB_LB_LB_LB',
+        'DB_DB_DB_DB_DB_DB_DB_DB',
+        'G_G_WD_WD_G_G_G_G',
+      ];
+      const cityWeights = [0.7, 0.075, 0.075, 0.075, 0.075];
+      w.prob_distr = cityKeys.map((k, i) => [cityWeights[i], k] as [number, string]);
+      const opts = [...w.global_options];
+      const counts: Record<string, number> = { G: 0, Y: 0, LB: 0, DB: 0, W: 0 };
+      const N = 8000;
+      for (let i = 0; i < N; i++) {
+        const t = w.sampleOptionsFromDistribution(opts);
+        const b = biome(t);
+        if (b in counts) counts[b]++;
+      }
+      return { N, counts };
+    });
+    const pGrass = cityResult.counts.G / cityResult.N;
+    // Aggregate P(Grass) should be ≈0.7. Pre-fix (with the per-tile-not-per-
+    // biome bug) this was ≈0.96 because grass has the most dominant tiles in
+    // the manifest.
+    expect(pGrass).toBeGreaterThan(0.65);
+    expect(pGrass).toBeLessThan(0.75);
+  });
+
+  // Verifies the seedable RNG: same ?seed= → same sequence of cell
+  // collapses. Uses the Step button to advance deterministically (no
+  // wall-clock race) and the wfc-extras UI added for issue #16 follow-up.
+  test('seed determinism + step button @multistep', async ({ page }) => {
+    const collect = async () => {
+      await page.goto(WFC_URL + '?seed=424242&autostart=0');
+      await waitForP5Ready(page);
+      // Confirm the seed propagated through the URL into the RNG state.
+      const seedFromWindow = await page.evaluate(
+        () => (window as unknown as { __wfcRngSeed: number }).__wfcRngSeed,
+      );
+      expect(seedFromWindow).toBe(424242);
+
+      await page.locator('#tileselect .image-container').filter({ hasText: /REDGRID_EASY/i }).locator('button').click();
+      await expect(page.locator('#STARTWFC')).toBeVisible();
+      await page.locator('#STARTWFC').click();
+      await expect(page.locator('#wfc-canvas canvas')).toBeVisible({ timeout: 15_000 });
+      await expect(page.locator('#wfc-extras')).toBeVisible();
+      // Seed input should also display the active seed.
+      await expect(page.locator('#wfc-seed')).toHaveValue('424242');
+
+      // Step several times. Each click forces one collapse + propagation.
+      for (let i = 0; i < 6; i++) {
+        await page.locator('#wfc-step').click();
+        await page.waitForTimeout(60);
+      }
+      // Snapshot a deterministic fingerprint of the grid: every cell's
+      // first option, in position order.
+      return page.evaluate(() => {
+        const w = window as unknown as {
+          grid_list: Array<{ position: [number, number]; options: string[] }>;
+        };
+        return w.grid_list
+          .slice()
+          .sort((a, b) => a.position[0] - b.position[0] || a.position[1] - b.position[1])
+          .map(c => c.options[0] || '')
+          .join('|');
+      });
+    };
+    const first = await collect();
+    const second = await collect();
+    expect(first).toBe(second);
+    // Sanity: at least one cell collapsed, otherwise the test would pass
+    // trivially on empty grids.
+    expect(first.replace(/\|/g, '').length).toBeGreaterThan(0);
+  });
+
+  // Mixed-initiative click-to-collapse: clicking an uncollapsed cell on
+  // the canvas opens a popover whose thumbnails force that cell's
+  // collapse choice.
+  test('click-to-collapse opens popover and applies choice @multistep', async ({ page }) => {
+    await page.goto(WFC_URL_FROZEN);
+    await waitForP5Ready(page);
+    await page.locator('#tileselect .image-container').filter({ hasText: /REDGRID_EASY/i }).locator('button').click();
+    await page.locator('#STARTWFC').click();
+    const canvas = page.locator('#wfc-canvas canvas');
+    await expect(canvas).toBeVisible({ timeout: 15_000 });
+
+    // Click roughly the centre of the canvas — with the default grid_size
+    // of 2 that lands inside a cell. The popover renders inside #wfc-canvas
+    // so it inherits the host's positioning.
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error('canvas box missing');
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+
+    const popover = page.locator('.wfc-popover');
+    await expect(popover).toBeVisible({ timeout: 5_000 });
+    // At least one option thumbnail rendered.
+    const thumbs = popover.locator('img');
+    await expect(thumbs.first()).toBeVisible();
+
+    // Capture which tile name we're about to pick, then click it.
+    const chosen = await thumbs.first().getAttribute('alt');
+    await thumbs.first().click();
+    // Popover dismisses on selection.
+    await expect(popover).toHaveCount(0);
+
+    // The chosen cell should reach options.length === 1 (the picked tile)
+    // after the next render tick processes the queued manual collapse.
+    await page.waitForFunction(
+      (target) => {
+        const w = window as unknown as {
+          grid_list: Array<{ options: string[] }>;
+        };
+        return w.grid_list.some(c => c.options.length === 1 && c.options[0] === target);
+      },
+      chosen,
+      { timeout: 5_000 },
+    );
+  });
+
+  // Regression: clicking near the bottom-right corner of the canvas used
+  // to render the popover overflowing the canvas host (right/bottom
+  // edges off-screen). Now openPopoverForCell measures the popover and
+  // clamps left/top to stay inside the host bounds.
+  test('click-to-collapse popover stays inside canvas bounds @multistep', async ({ page }) => {
+    await page.goto(WFC_URL_FROZEN);
+    await waitForP5Ready(page);
+    await page.locator('#tileselect .image-container').filter({ hasText: /REDGRID_EASY/i }).locator('button').click();
+    await page.locator('#STARTWFC').click();
+    const canvas = page.locator('#wfc-canvas canvas');
+    await expect(canvas).toBeVisible({ timeout: 15_000 });
+
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error('canvas box missing');
+    // Click within the bottom-right cell (grid_size defaults to 2 → cells
+    // are half the canvas; clicking near the corner used to push the
+    // popover off-screen).
+    await page.mouse.click(box.x + box.width - 6, box.y + box.height - 6);
+
+    const popover = page.locator('.wfc-popover');
+    await expect(popover).toBeVisible({ timeout: 5_000 });
+
+    // The popover's bounding rect must sit inside #wfc-canvas's bounding
+    // rect (with a few pixels of slack for borders/margins). Skip the
+    // check on small viewports where the popover is a bottom sheet
+    // anchored by CSS rather than positioned by JS.
+    const placement = await page.evaluate(() => {
+      const host = document.getElementById('wfc-canvas');
+      const pop = document.querySelector('.wfc-popover');
+      if (!host || !pop) return null;
+      const h = host.getBoundingClientRect();
+      const p = pop.getBoundingClientRect();
+      return {
+        hostLeft: h.left, hostTop: h.top, hostRight: h.right, hostBottom: h.bottom,
+        popLeft: p.left, popTop: p.top, popRight: p.right, popBottom: p.bottom,
+        isMobile: window.matchMedia('(max-width: 640px)').matches,
+      };
+    });
+    if (!placement) throw new Error('placement read failed');
+    if (!placement.isMobile) {
+      expect(placement.popLeft).toBeGreaterThanOrEqual(placement.hostLeft - 1);
+      expect(placement.popTop).toBeGreaterThanOrEqual(placement.hostTop - 1);
+      expect(placement.popRight).toBeLessThanOrEqual(placement.hostRight + 1);
+      expect(placement.popBottom).toBeLessThanOrEqual(placement.hostBottom + 1);
+    }
+  });
+
+  // Regression for the "second collapse looks bugged" report: complete a
+  // CITY run, hit Reset, pick CITY again, click STARTWFC, and verify the
+  // canvas comes back to a fresh state (grid is uncollapsed, status_button
+  // shows the initial label, Pause state is reset) before the user clicks
+  // anything else.
+  test('second collapse on CITY grid is fully reset @multistep', async ({ page }) => {
+    await page.goto(WFC_URL_FROZEN);
+    await waitForP5Ready(page);
+
+    // --- First run: CITY, grid 2, step through every cell ---
+    await page.locator('#tileselect .image-container').filter({ hasText: /CITY/i }).locator('button').click();
+    await page.locator('#STARTWFC').click();
+    await expect(page.locator('#wfc-canvas canvas')).toBeVisible({ timeout: 15_000 });
+
+    // Run to completion via repeated Step clicks (deterministic, no
+    // races with auto-throttling). grid_size defaults to 2 → 4 cells,
+    // but backtracking can re-visit; cap iterations generously.
+    for (let i = 0; i < 40; i++) {
+      const done = await page.evaluate(() => {
+        const w = window as unknown as {
+          grid_list: Array<{ options: string[] }>;
+        };
+        return w.grid_list.length > 0 && w.grid_list.every(c => c.options.length === 1);
+      });
+      if (done) break;
+      await page.locator('#wfc-step').click();
+      await page.waitForTimeout(120);
+    }
+    const finishedFirst = await page.evaluate(() => {
+      const w = window as unknown as {
+        grid_list: Array<{ options: string[] }>;
+      };
+      return w.grid_list.length > 0 && w.grid_list.every(c => c.options.length === 1);
+    });
+    expect(finishedFirst).toBe(true);
+
+    // --- Reset back to step 1 ---
+    await page.locator('#resetButton').click();
+    await expect(page.locator('#tileselect')).toBeVisible();
+
+    // --- Second run: pick CITY again, click STARTWFC ---
+    await page.locator('#tileselect .image-container').filter({ hasText: /CITY/i }).locator('button').click();
+    await expect(page.locator('#STARTWFC')).toBeVisible();
+    await page.locator('#STARTWFC').click();
+    await expect(page.locator('#wfc-canvas canvas')).toBeVisible({ timeout: 15_000 });
+
+    // Right after STARTWFC, before any further user action, the grid
+    // should be in a fresh state — every cell has multiple options
+    // remaining. Pre-fix this still held the collapsed grid from run 1.
+    const fresh = await page.evaluate(() => {
+      const w = window as unknown as {
+        grid_list: Array<{ options: string[] }>;
+        status_bool: boolean;
+        isPaused?: boolean;
+      };
+      return {
+        cellCount: w.grid_list.length,
+        allUncollapsed: w.grid_list.every(c => c.options.length > 1),
+        statusBool: w.status_bool,
+      };
+    });
+    expect(fresh.cellCount).toBeGreaterThan(0);
+    expect(fresh.allUncollapsed).toBe(true);
+    expect(fresh.statusBool).toBe(false);
+
+    // And the Play/Pause toggle should read "Pause" (i.e. unpaused) on a
+    // fresh run, even if the previous run left isPaused=true via Step.
+    await expect(page.locator('#wfc-play')).toHaveText('Pause');
+
+    // The grid-size slider lives inside #wfc-primary, and #wfc-primary
+    // must come before #wfc-extras inside #wfc-controls. Pre-fix the
+    // bslider would migrate below #wfc-extras on the second STARTWFC and
+    // looked "gone" to the user.
+    const sliderPosition = await page.evaluate(() => {
+      const ctrl = document.getElementById('wfc-controls');
+      const primary = document.getElementById('wfc-primary');
+      const extras = document.getElementById('wfc-extras');
+      if (!ctrl || !primary || !extras) return { found: false };
+      const slider = primary.querySelector('input[type="range"]') as HTMLInputElement | null;
+      if (!slider) return { found: false };
+      const kids = Array.from(ctrl.children);
+      return {
+        found: true,
+        primaryIdx: kids.indexOf(primary),
+        extrasIdx: kids.indexOf(extras),
+        sliderInsidePrimary: slider.parentElement === primary,
+      };
+    });
+    expect(sliderPosition.found).toBe(true);
+    expect(sliderPosition.sliderInsidePrimary).toBe(true);
+    expect(sliderPosition.primaryIdx).toBeLessThan(sliderPosition.extrasIdx as number);
+
+    // Sanity: the algorithm is alive after second STARTWFC. We can't
+    // assert "one Step → one collapsed cell" because on tiny CITY grids
+    // (2x2) the very first propagation can hit optionsError with an
+    // empty backtracking history; recovery then wipes to a fresh grid,
+    // leaving the collapsed-cell count back at 0. Instead, step a few
+    // times and verify the engine is still healthy — `status_bool`
+    // alternates between true and false as part of the normal pick /
+    // propagate cycle, and the grid stays a valid array of cells.
+    for (let i = 0; i < 4; i++) {
+      await page.locator('#wfc-step').click();
+      await page.waitForTimeout(120);
+    }
+    const alive = await page.evaluate(() => {
+      const w = window as unknown as {
+        grid_list: Array<{ options: string[]; position: [number, number] }>;
+      };
+      return {
+        isArray: Array.isArray(w.grid_list),
+        size: w.grid_list.length,
+        allCellsValid: w.grid_list.every(
+          c => Array.isArray(c.options) && Array.isArray(c.position) && c.position.length === 2,
+        ),
+      };
+    });
+    expect(alive.isArray).toBe(true);
+    expect(alive.size).toBeGreaterThan(0);
+    expect(alive.allCellsValid).toBe(true);
+  });
+
+  // Regression: large CITY grids could drain the backtracking history
+  // mid-recovery, causing old_grids.pop() to return undefined. The
+  // undefined `grid_list` then hit `.some(...)` inside checkDirection,
+  // threw, and the secondary throw killed p5's draw loop — leaving the
+  // canvas frozen and the Restart button without a render path.
+  // We trigger the failure path directly (clearing old_grids + tracking
+  // mid-backtrack) and verify draw() recovers without freezing.
+  test('backtracking exhaustion does not freeze draw loop @multistep', async ({ page }) => {
+    await page.goto(WFC_URL_FROZEN);
+    await waitForP5Ready(page);
+    await page.locator('#tileselect .image-container').filter({ hasText: /CITY/i }).locator('button').click();
+    await page.locator('#STARTWFC').click();
+    await expect(page.locator('#wfc-canvas canvas')).toBeVisible({ timeout: 15_000 });
+
+    // Run a couple of Step ticks so the algorithm has SOMETHING in its
+    // tracking / old_grids buffers and `neighbour` references a real cell.
+    await page.locator('#wfc-step').click();
+    await page.waitForTimeout(60);
+    await page.locator('#wfc-step').click();
+    await page.waitForTimeout(60);
+
+    // Force the failure mode: drain history while leaving backtracking=true
+    // and a stale `neighbour`. Pre-fix, the next draw frame popped
+    // undefined into grid_list and the loop crashed.
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        old_grids: unknown[];
+        tracking: unknown[];
+        backtracking: boolean;
+        status_bool: boolean;
+      };
+      w.old_grids = [];
+      w.tracking = [];
+      w.backtracking = true;
+      w.status_bool = true;
+    });
+
+    // Drive a few draw cycles by clicking Step (which sets forceStepOnce
+    // so the algorithm advances even though we forced isPaused earlier
+    // via the Step button).
+    for (let i = 0; i < 3; i++) {
+      await page.locator('#wfc-step').click();
+      await page.waitForTimeout(150);
+    }
+
+    // Two things should now hold:
+    //   1. window.__wfcReady is still true (the bootstrap flag).
+    //   2. The Restart button (status_button) still drives a state reset.
+    const ready = await page.evaluate(
+      () => (window as unknown as { __wfcReady?: boolean }).__wfcReady === true,
+    );
+    expect(ready).toBe(true);
+
+    // Hit Restart through the p5 status_button. Pre-fix this set state
+    // but draw() never ran again, so grid_list stayed undefined.
+    await page.evaluate(() => {
+      const w = window as unknown as { changeState: () => void };
+      w.changeState();
+    });
+    await page.waitForTimeout(200);
+
+    // After Restart, grid_list is a non-empty array. Pre-fix it was
+    // undefined (because old_grids.pop() returned undefined inside the
+    // backtracking catch and the secondary throw killed draw()).
+    const afterRestart = await page.evaluate(() => {
+      const w = window as unknown as {
+        grid_list: Array<{ options: string[] }>;
+      };
+      return {
+        gridLen: Array.isArray(w.grid_list) ? w.grid_list.length : -1,
+      };
+    });
+    expect(afterRestart.gridLen).toBeGreaterThan(0);
+
+    // Wait for the auto-run to make progress — changeState() leaves
+    // isPaused=false and status_bool=true, so the draw loop should
+    // collapse cells over the next few frames. If draw() were dead
+    // (the pre-fix symptom), no cells would collapse here.
+    await page.waitForTimeout(400);
+    const progress = await page.evaluate(() => {
+      const w = window as unknown as {
+        grid_list: Array<{ options: string[] }>;
+      };
+      return w.grid_list.filter(c => c.options.length === 1).length;
+    });
+    expect(progress).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- **Closes #16** — CITY tileset's biome sliders now produce the aggregate probability the UI implies. Pre-fix: Grass=80% → ~96% grass; post-fix: Grass=80% → ~70% (against a 4-biome cell). Per-biome divisor in `createNewNormalisedDistr` so the sum of weights for any biome equals its slider value.
- Substantial widget overhaul on top of the fix (each step explicitly authorised in conversation): refactor for correctness/perf, six new features, mobile-first UX, an in-widget help panel, and resilience against backtrack-exhaustion crashes.

## What's in the diff

| Category | Change |
|---|---|
| **Bug fix** | `createNewNormalisedDistr` divides each tile's weight by the count of options sharing its biome marker |
| **Refactor** | `'use strict'`, declared all locals, `samePos` replaces `JSON.stringify` equality in grid lookups, structural `cloneGrid` (no JSON deep-clone), cached `cityBiomeMarker`, lifted direction-vector consts |
| **Features** | Mulberry32 seeded RNG (`?seed=` + Share button writes URL), Pause/Play/Step with speed throttle (0–500ms/step), entropy heatmap on uncollapsed cells, red backtrack flash, PNG export, click-to-collapse mixed-initiative popover |
| **UI** | Stable `#wfc-primary` wrapper (fixes slider-disappears-on-second-collapse), auto-start on STARTWFC (`?autostart=0` opt-out), Run/Restart label, primary-styled Step button, CITY max grid size 8 → 32, `<details>` how-to-use panel revealed on tileset selection |
| **Safety** | Defensive guards on `old_grids.pop()` (was popping undefined into `grid_list` → crashed p5's draw loop and froze Restart on large CITY grids); outer `try/catch` in `draw()` auto-recovers any residual throw |
| **Mobile** | Bottom-sheet popover at ≤640px, 36–40px tap targets, full-width sliders, popover clamped to canvas on desktop |

## Test plan

All new behaviour ships with `@multistep` e2e tests (chromium + firefox + webkit + mobile-chrome). Verified 5/5 full WFC suite runs clean across all three desktop browsers (30 tests each).

- [x] `sampleOptionsFromDistribution honors prob_distr weights` — REDGRID per-tile within ±0.03; CITY P(Grass) ∈ [0.65, 0.75]
- [x] `seed determinism + step button` — same `?seed=` produces identical grid fingerprint across reloads
- [x] `click-to-collapse opens popover and applies choice`
- [x] `click-to-collapse popover stays inside canvas bounds` — bounding rect inside `#wfc-canvas` on desktop
- [x] `second collapse on CITY grid is fully reset` — grid uncollapsed after second STARTWFC, slider inside `#wfc-primary`, algorithm still alive after recovery
- [x] `backtracking exhaustion does not freeze draw loop` — drain `old_grids`+`tracking` mid-run, verify changeState restart + progress
- [x] `WFC click-to-collapse popover is a bottom sheet on mobile` (Pixel 5)
- [x] `WFC widget renders without horizontal overflow on mobile`
- [x] Existing tests (`reset returns to step 1`, `running the collapse renders a p5 canvas`, etc.) still pass

## Manual verification

- Try a few seeds: `/posts/wfc?seed=424242`, `/posts/wfc?seed=1`
- CITY tileset, grid 8+, drag Speed up to ~250ms to watch propagation
- Click an uncollapsed cell on the canvas to open the choose-a-tile popover; thumbnails are clickable
- Resize browser to mobile width — popover anchors to viewport bottom, controls remain tappable
- Share button copies the current run's URL; Save PNG downloads the canvas

## Security

`/security-review` ran clean in the same session — no findings. New URL params are integer-coerced; the lone `innerHTML` site uses a fully static template literal; popover DOM is built via `createElement` + `.textContent`/`.alt`/`.title`/`.src`; mulberry32 is non-crypto and only drives visual tile selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)