### PR TITLE
feat(wfc): block solver for large CITY grids

### DIFF
--- a/content/posts/wfc.mdx
+++ b/content/posts/wfc.mdx
@@ -74,13 +74,12 @@ video game esque maps up to the 8x8 grid size.
 
 
 ## Increasing generality
-The astute readers may have noticed that, when changing tileset from Red Grid to City, the maximum grid size is reduced from
-30 down to 8, this is because the City tileset is considerably more prone to reaching unsolvable states due to the significantly
-larger set of tiles and inherent incompatibility between tiles from different biomes. In order to remedy this Merrell, in his Ph.D. Thesis[^Thesis], 
-describes an adapation to the WFC algorithm that allows it to drastically increase its chances of solving large grid sizes.
-The adaptation is called 'Modification in Blocks' and solves the problem by breaking down the grid into smaller subsections
-then performing the following:
-- Precompute: set of known good tiles that will always allow a path to continue beyond the border of a subsection,
+The City tileset is considerably more prone to reaching unsolvable states than Red Grid, due to the significantly
+larger set of tiles (107 vs. a handful) and inherent incompatibility between tiles from different biomes. Without help,
+the global backtracking tree blows up well before a 30x30 grid is filled. Merrell, in his Ph.D. Thesis[^Thesis],
+describes an adapation to the WFC algorithm that addresses this: **Modification in Blocks**. Instead of solving the
+whole grid at once, the algorithm breaks it down into smaller subsections:
+- Precompute: a set of known good tiles that will always allow a path to continue beyond the border of a subsection,
 1. Select a subsection,
 2. Run WFC on the subsection, while adherring to any adjacent subsection's adjacency constraints,
     - When running WFC on the edge of a subsection intersect the domain of the tiles with the set of precomputed "good" tiles,
@@ -90,7 +89,13 @@ then performing the following:
 The subsections are selected in an order that is exactly like a convolutional filter from a Convolutional Neural network and as such Figure 2, adapted from NamyaLG[^Namya],
 shows where/how the WFC algorithm is run on the overall grid.
 <Figure src='/WFC_code/filter.gif' caption='Visualisation of a Convolutional Filter/Modification in Blocks Subsection Selection' number='2' />
-In the future I plan to implement "Modification in Blocks" and to allow the grid size to be increased up to 30 again, a subsequent blog article will follow.
+This is now wired into the City tileset above: at grid sizes above 8, the widget switches to a 6x6 block solver with a 1-cell
+overlap (stride 5), scan-line traversal, and the all-grass tile `G_G_G_G_G_G_G_G` used as the known-good "ground" pre-fill on
+open block borders. Before the first cell in each block is sampled, constraints from already-fixed neighbours (the prior block's
+overlap edge plus the ground seeds) are propagated inward so the block samples from an already-filtered option set — without
+this step, blocks meet at visibly incompatible seams. Each block has a bounded retry budget; on the rare cases where a block
+still can't satisfy its constraints the un-collapsed cells fall back to ground rather than triggering a whole-grid restart.
+A `block X / Y` readout under the canvas tracks progress so you can watch the convolutional fill in motion.
 ## Conclusion
 This article explored the Wave Function Collapse (WFC) algorithm, a powerful tool for procedural content generation.
  It delved into the step-by-step process, from cell selection to resolving conflicts through backtracking. 

--- a/public/WFC_code/wfc.css
+++ b/public/WFC_code/wfc.css
@@ -420,6 +420,21 @@
   min-width: 42px;
 }
 
+/* Block-WFC progress readout. Visible only while the block solver is
+   active — single-pass runs (REDGRID, small CITY) keep this hidden. */
+.wfc-block-status {
+  font-family: var(--font-family-mono, monospace);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  color: var(--color-gray);
+  letter-spacing: 0.03em;
+  padding: 4px 0 0;
+}
+.wfc-block-status-toast {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
 .wfc-extras input[type='number'] {
   font-family: inherit;
   font-size: 12px;

--- a/public/WFC_code/wfc.js
+++ b/public/WFC_code/wfc.js
@@ -80,6 +80,38 @@ const CARD_DIRS = [[0, -1], [0, 1], [-1, 0], [1, 0]];
 const EIGHT_DIRS = [[0, -1], [0, 1], [-1, 0], [1, 0], [1, -1], [-1, -1], [1, 1], [-1, 1]];
 const dirsFor = () => (tileset.includes('CITY') ? EIGHT_DIRS : CARD_DIRS);
 
+// --- Block-WFC constants (Merrell's "modification in blocks") ----------
+// Activated only for CITY at grid sizes above BLOCK_THRESHOLD. Below
+// that, the single-pass solver still works and adding seams + retries
+// would cost more than it pays. Above it, the 107-tile / 8-direction
+// search space makes global backtracking pathological.
+const BLOCK_SIZE = 6;
+const BLOCK_STRIDE = 5;           // overlap = BLOCK_SIZE - BLOCK_STRIDE = 1 cell
+// Retry budget per block — 6×6 = 36 cells × 107 CITY tiles has a much wider
+// internal search than 4×4, so the historical "8 retries" budget exhausted
+// before finding a feasible configuration at grid sizes ~25+. 24 gives the
+// inner WFC enough attempts to thread the needle on most blocks; remaining
+// failures still ground-fill cleanly.
+const BLOCK_MAX_RETRIES = 24;
+const BLOCK_THRESHOLD = 8;
+const BLOCK_GROUND_TILE = 'G_G_G_G_G_G_G_G';
+
+// blockSolver shape — null when single-pass mode is active.
+//   {
+//     gridSize,
+//     blocks: [{bx, by}, ...],
+//     blockIdx,                       // 0..blocks.length
+//     state: null | {                 // null between blocks
+//       bx, by,
+//       modRegionPositions,           // [[x,y]] — positions, not refs (refs go
+//                                     //   stale on cloneGrid+replace)
+//       tempSeedSnapshots,            // [{pos, prevOptions, prevFixed}]
+//       retryCount,
+//       snapshot,                     // [{pos, options, fixed}] for modRegion
+//     }
+//   }
+var blockSolver = null;
+
 // --- Grid helpers -------------------------------------------------------
 
 const samePos = (a, b) => a[0] === b[0] && a[1] === b[1];
@@ -169,6 +201,8 @@ function startWFC() {
   manualCollapseQueued = null;
   forceStepOnce = false;
   isPaused = false;
+  resetBlockSolver();
+  if (shouldUseBlockSolver()) initBlockSolver();
 
   // Auto-run by default — clicking "start collapse →" should actually
   // start the collapse, not just transition to step 3. Tests that need
@@ -520,6 +554,8 @@ function changeState() {
   recentBacktrack = null;
   manualCollapseQueued = null;
   isPaused = false;
+  resetBlockSolver();
+  if (shouldUseBlockSolver()) initBlockSolver();
   const playBtn = document.getElementById('wfc-play');
   if (playBtn) playBtn.textContent = 'Pause';
   redraw();
@@ -604,9 +640,22 @@ function leastEntropy(grid_list) {
 
 function reset_neighbours(bad_cell, grid_array) {
   const directions = dirsFor();
+  // Block-WFC: confine reset_neighbours to the current block's footprint.
+  // Otherwise it can un-fix cells from previously-solved blocks (the
+  // broken cell sitting near a block edge has neighbours outside the
+  // current block), letting subsequent propagation overwrite work the
+  // block solver considers permanent.
+  const blockState = blockSolver && blockSolver.state;
   directions.forEach(direction => {
     const result = checkDirection(direction, bad_cell, grid_array, [new gridSquare([-100, -100], 'FG')]);
     if (result) {
+      if (blockState) {
+        const [x, y] = result.position;
+        const inFootprint =
+          x >= blockState.bx && x < blockState.bx + BLOCK_SIZE &&
+          y >= blockState.by && y < blockState.by + BLOCK_SIZE;
+        if (!inFootprint) return;
+      }
       const found_cell = findByPos(grid_array, result.position);
       if (found_cell) found_cell.fixed = false;
     }
@@ -625,6 +674,267 @@ function sampleOptionsFromDistribution(options) {
     if (cumulative_sum >= rand_sample) return tile;
   }
   return tile;
+}
+
+// --- Block-WFC solver --------------------------------------------------
+//
+// Implementation of Merrell's "modification in blocks" from the WFC post
+// (content/posts/wfc.mdx:76-93). The grid is solved as a sequence of
+// overlapping 6×6 sub-grids in scanline order, with each block's open
+// boundary preseeded to the all-grass "ground" tile so the block always
+// has a feasible outward neighbour. Each block restarts up to N times on
+// failure; the final fallback is a ground-tile fill — never a full-grid
+// wipe, which is what the user previously saw as the canvas-wiping
+// "auto-restart" loop at large CITY sizes.
+//
+// Operates by mutating the shared grid_list — leaning on the existing
+// adjustPossibilities / leastEntropy / sampleOptionsFromDistribution
+// helpers. State is stored as POSITIONS, not cell refs, so it survives
+// the cloneGrid+replace pattern in the drawImpl error handler.
+
+function shouldUseBlockSolver() {
+  if (!tileset || !tileset.includes('CITY')) return false;
+  if (!bslider) return false;
+  return bslider.value() > BLOCK_THRESHOLD;
+}
+
+function blockGridIdx(pos) {
+  return pos[0] * blockSolver.gridSize + pos[1];
+}
+
+function blockCellAt(pos) {
+  // createGrid fills row-major as x outer, y inner — so x*N+y is the index.
+  return grid_list[blockGridIdx(pos)];
+}
+
+function initBlockSolver() {
+  const gridSize = bslider.value();
+  const blocks = [];
+  const seen = new Set();
+  const pushBlock = (bx, by) => {
+    const key = bx + ',' + by;
+    if (!seen.has(key)) { seen.add(key); blocks.push({ bx, by }); }
+  };
+  // Scanline scan; clamp the final block in each row/column to the grid
+  // edge when stride doesn't divide evenly so we still cover the corner.
+  for (let by = 0; by + BLOCK_SIZE <= gridSize; by += BLOCK_STRIDE) {
+    for (let bx = 0; bx + BLOCK_SIZE <= gridSize; bx += BLOCK_STRIDE) {
+      pushBlock(bx, by);
+    }
+    if ((gridSize - BLOCK_SIZE) % BLOCK_STRIDE !== 0) {
+      pushBlock(gridSize - BLOCK_SIZE, by);
+    }
+  }
+  if ((gridSize - BLOCK_SIZE) % BLOCK_STRIDE !== 0) {
+    for (let bx = 0; bx + BLOCK_SIZE <= gridSize; bx += BLOCK_STRIDE) {
+      pushBlock(bx, gridSize - BLOCK_SIZE);
+    }
+    pushBlock(gridSize - BLOCK_SIZE, gridSize - BLOCK_SIZE);
+  }
+  blockSolver = { gridSize, blocks, blockIdx: 0, state: null };
+}
+
+function startBlock() {
+  const bs = blockSolver;
+  if (!bs || bs.blockIdx >= bs.blocks.length) return false;
+  const { bx, by } = bs.blocks[bs.blockIdx];
+  const gridSize = bs.gridSize;
+
+  const modRegionPositions = [];
+  for (let dx = 0; dx < BLOCK_SIZE; dx++) {
+    for (let dy = 0; dy < BLOCK_SIZE; dy++) {
+      const x = bx + dx, y = by + dy;
+      const cell = blockCellAt([x, y]);
+      if (cell && !cell.fixed) modRegionPositions.push([x, y]);
+    }
+  }
+
+  // Boundary: 1-cell ring around the footprint, within grid bounds.
+  // Already-fixed boundary cells contribute constraints as-is; unsolved
+  // boundary cells get temporarily seeded to GROUND so the block always
+  // has a feasible outward neighbour (Merrell's "ground" pre-fill).
+  const tempSeedSnapshots = [];
+  const isInFootprint = (x, y) =>
+    x >= bx && x < bx + BLOCK_SIZE && y >= by && y < by + BLOCK_SIZE;
+  for (let dx = -1; dx <= BLOCK_SIZE; dx++) {
+    for (let dy = -1; dy <= BLOCK_SIZE; dy++) {
+      const x = bx + dx, y = by + dy;
+      if (x < 0 || y < 0 || x >= gridSize || y >= gridSize) continue;
+      if (isInFootprint(x, y)) continue;
+      const cell = blockCellAt([x, y]);
+      if (!cell || cell.fixed) continue;
+      tempSeedSnapshots.push({
+        pos: [x, y],
+        prevOptions: cell.options.slice(),
+        prevFixed: cell.fixed,
+      });
+      cell.options = [BLOCK_GROUND_TILE];
+      cell.fixed = true;
+    }
+  }
+
+  // Pre-propagate fixed-cell constraints into modRegion BEFORE the first
+  // collapse samples. adjustPossibilities skips already-fixed cells when
+  // it encounters them mid-BFS (`if (current_cell.fixed === true)
+  // continue;`), so a fixed cell only acts as a constraint source when
+  // it's the BFS seed — i.e. when adjustPossibilities is called with it
+  // explicitly. Without this pass, the first collapse in a new block
+  // samples from un-filtered options, picks something incompatible with
+  // the prior-block overlap or the boundary seeds, and creates the
+  // visible inter-block seam. We loop over every fixed cell adjacent to
+  // modRegion and propagate from each.
+  const dirs = dirsFor();
+  const seeded = new Set();
+  let preProp_ok = true;
+  for (const [x, y] of modRegionPositions) {
+    if (!preProp_ok) break;
+    for (const [dx, dy] of dirs) {
+      const nx = x + dx, ny = y + dy;
+      if (nx < 0 || ny < 0 || nx >= gridSize || ny >= gridSize) continue;
+      const key = nx + ',' + ny;
+      if (seeded.has(key)) continue;
+      const neighbour = blockCellAt([nx, ny]);
+      if (!neighbour || !neighbour.fixed) continue;
+      seeded.add(key);
+      try {
+        adjustPossibilities(neighbour, grid_list);
+      } catch (e) {
+        if (e instanceof optionsError) {
+          preProp_ok = false;
+          break;
+        }
+        throw e;
+      }
+    }
+  }
+
+  if (!preProp_ok) {
+    // Boundary configuration is internally inconsistent — the prior
+    // block's edge cells contradict our ground seeds, or two prior
+    // blocks meet with incompatible tiles at this corner. Retrying with
+    // the same boundary won't help (it's deterministic), so we skip
+    // straight to ground-fill of the modRegion and advance. This is the
+    // same fallback as exhausting BLOCK_MAX_RETRIES.
+    console.warn('[wfc] block pre-propagation contradiction at (' + bx + ',' + by + '); ground-filling');
+    modRegionPositions.forEach(pos => {
+      const c = blockCellAt(pos);
+      if (!c) return;
+      c.options = [BLOCK_GROUND_TILE];
+      c.fixed = true;
+      c.underInspection = false;
+    });
+    tempSeedSnapshots.forEach(({ pos, prevOptions, prevFixed }) => {
+      const c = blockCellAt(pos);
+      if (!c) return;
+      c.options = prevOptions.slice();
+      c.fixed = prevFixed;
+    });
+    bs.blockIdx += 1;
+    bs.state = null;
+    tracking = [];
+    old_grids = [];
+    return false;
+  }
+
+  // Snapshot of modRegion AFTER pre-propagation — block-local restart
+  // reverts the working set to this filtered state, not back to all-
+  // options. Restoring to the unconstrained pre-propagation state would
+  // re-introduce the seam bug on every retry.
+  const snapshot = modRegionPositions.map(pos => {
+    const c = blockCellAt(pos);
+    return { pos: pos.slice(), options: c.options.slice(), fixed: c.fixed };
+  });
+
+  bs.state = {
+    bx, by,
+    modRegionPositions,
+    tempSeedSnapshots,
+    retryCount: 0,
+    snapshot,
+  };
+  // Per-block backtracking history. The shared `tracking` / `old_grids`
+  // arrays must not span block boundaries — otherwise a contradiction in
+  // block N can roll back grid state to before block 1 (undoing every
+  // earlier block's solved cells). Clearing here bounds the rollback
+  // depth to "within the current block".
+  tracking = [];
+  old_grids = [];
+  return true;
+}
+
+// Live cell refs for the current block's modification region. Recomputed
+// each time because cloneGrid+replace in the error handler swaps the cell
+// object identities — keeping refs in state would point at stale cells.
+function blockModRegionCells() {
+  const bs = blockSolver;
+  if (!bs || !bs.state) return [];
+  return bs.state.modRegionPositions
+    .map(pos => blockCellAt(pos))
+    .filter(Boolean);
+}
+
+function blockModRegionDone() {
+  const cells = blockModRegionCells();
+  if (cells.length === 0) return true;
+  return cells.every(c => c.options.length === 1);
+}
+
+function restoreBlockSnapshot() {
+  const st = blockSolver && blockSolver.state;
+  if (!st) return;
+  st.snapshot.forEach(s => {
+    const c = blockCellAt(s.pos);
+    if (!c) return;
+    c.options = s.options.slice();
+    c.fixed = s.fixed;
+    c.underInspection = false;
+  });
+}
+
+function finishBlock(success) {
+  const bs = blockSolver;
+  if (!bs || !bs.state) return;
+  const st = bs.state;
+
+  if (success) {
+    // Mark modRegion cells as permanently fixed so they constrain future
+    // blocks without being re-collapsed.
+    st.modRegionPositions.forEach(pos => {
+      const c = blockCellAt(pos);
+      if (c) c.fixed = true;
+    });
+  } else {
+    // Retries exhausted — ground-fill remaining modRegion cells. Visually
+    // plain but never locks up. Boris-the-Brave's writeup of Merrell's
+    // fallback describes the same approach.
+    st.modRegionPositions.forEach(pos => {
+      const c = blockCellAt(pos);
+      if (!c) return;
+      c.options = [BLOCK_GROUND_TILE];
+      c.fixed = true;
+      c.underInspection = false;
+    });
+  }
+
+  // Unseed temporary boundary tiles so the next overlapping block can
+  // re-collapse them with proper context.
+  st.tempSeedSnapshots.forEach(({ pos, prevOptions, prevFixed }) => {
+    const c = blockCellAt(pos);
+    if (!c) return;
+    c.options = prevOptions.slice();
+    c.fixed = prevFixed;
+  });
+
+  bs.state = null;
+  bs.blockIdx += 1;
+  // Block-local backtracking history must not leak across block
+  // boundaries (see comment in startBlock).
+  tracking = [];
+  old_grids = [];
+}
+
+function resetBlockSolver() {
+  blockSolver = null;
 }
 
 // --- Run-extras UI (speed / step / seed / share / save / popover) ------
@@ -650,6 +960,7 @@ function ensureRunControls() {
       <button id="wfc-share" type="button" title="Copy a URL that reproduces this run">Share</button>
       <button id="wfc-save" type="button" title="Download the canvas as PNG">Save PNG</button>
     </div>
+    <div id="wfc-block-status" class="wfc-block-status" hidden></div>
   `;
   host.appendChild(extras);
 
@@ -804,6 +1115,21 @@ function openPopoverForCell(cell, screenX, screenY) {
   pop.style.visibility = '';
 }
 
+// Brief inline toast under the canvas. Reuses #wfc-block-status as the
+// visual surface — the block-status text reappears on the next frame
+// after the timeout expires.
+function flashCanvasToast(msg) {
+  const el = document.getElementById('wfc-block-status');
+  if (!el) return;
+  el.hidden = false;
+  el.textContent = msg;
+  el.classList.add('wfc-block-status-toast');
+  setTimeout(() => {
+    el.classList.remove('wfc-block-status-toast');
+    updateBlockStatus();
+  }, 1800);
+}
+
 function thumbSrcForOption(name) {
   // Walk the manifest for a tile file matching the active tileset whose
   // basename (sans extension) equals `name`. Manifest paths are absolute
@@ -826,6 +1152,8 @@ function ensureGridReady() {
     old_grids = [];
     backtracking = false;
     recentBacktrack = null;
+    resetBlockSolver();
+    if (shouldUseBlockSolver()) initBlockSolver();
   }
 }
 
@@ -846,6 +1174,22 @@ function canvasClickHandler(evt) {
   const cell = findByPos(grid_list, [cx, cy]);
   if (!cell) return;
   if (cell.options.length <= 1) return; // nothing to choose
+
+  // Block-WFC: manual collapse is only meaningful for cells in the block
+  // currently being solved. Other cells are either already fixed (handled
+  // above) or scheduled to be reached by a future block — show a brief
+  // toast and bail out rather than opening a popover that would queue a
+  // collapse the engine can't apply.
+  if (blockSolver) {
+    const st = blockSolver.state;
+    const inCurrentBlock = st &&
+      cx >= st.bx && cx < st.bx + BLOCK_SIZE &&
+      cy >= st.by && cy < st.by + BLOCK_SIZE;
+    if (!inCurrentBlock) {
+      flashCanvasToast('not yet reachable — that cell is in a future block');
+      return;
+    }
+  }
 
   // Pause so the popover sticks around while the reader decides.
   isPaused = true;
@@ -943,12 +1287,44 @@ function pickAndCollapseOne() {
   }
   if (finishedCollapse(grid_list)) return;
 
+  // Block-WFC: pick within the current block's modification region
+  // instead of the whole grid. Block transitions happen lazily here so
+  // the per-frame budget in drawImpl stays unchanged.
+  let pickPool = grid_list;
+  if (blockSolver) {
+    if (!blockSolver.state) {
+      if (blockSolver.blockIdx >= blockSolver.blocks.length) return;
+      startBlock();
+      // If startBlock found nothing to do (entire footprint already fixed
+      // from prior-block overlap), advance and try the next block. Don't
+      // loop indefinitely — capped at blocks.length to keep this O(N).
+      let safety = blockSolver.blocks.length;
+      while (blockSolver.state &&
+             blockSolver.state.modRegionPositions.length === 0 &&
+             safety-- > 0) {
+        finishBlock(true);
+        if (blockSolver.blockIdx >= blockSolver.blocks.length) return;
+        startBlock();
+      }
+      if (!blockSolver.state) return;
+    }
+    if (blockModRegionDone()) {
+      finishBlock(true);
+      return;
+    }
+    pickPool = blockModRegionCells();
+    if (pickPool.length === 0) {
+      finishBlock(true);
+      return;
+    }
+  }
+
   switch_bool = true;
   if (switch_bool && filled_count < 0.2 * grid_list.length) {
-    const neighbour_pos = getRandomUnCollapsedCell(grid_list);
+    const neighbour_pos = getRandomUnCollapsedCell(pickPool);
     neighbour = findByPos(grid_list, neighbour_pos);
   } else {
-    neighbour = leastEntropy(grid_list);
+    neighbour = leastEntropy(pickPool);
   }
   const collapsed_tile = sampleOptionsFromDistribution(neighbour.options);
   forbacktrack = new trackingObj(neighbour, neighbour.options);
@@ -1072,12 +1448,35 @@ function drawImpl() {
             }
           }
           if (!solvable) {
-            // Out of backtracking options — wipe history and start a
-            // fresh grid so the run can keep making forward progress.
-            old_grids = [];
-            tracking = [];
-            backtracking = false;
-            grid_list = bslider ? createGrid(bslider.value(), true) : [];
+            if (blockSolver && blockSolver.state) {
+              // Block-WFC failure path: per-block restart instead of a
+              // grid-wide wipe. After BLOCK_MAX_RETRIES the block falls
+              // back to ground-fill and the next block kicks in — so the
+              // overall run keeps making forward progress even on hard
+              // CITY configurations.
+              old_grids = [];
+              tracking = [];
+              backtracking = false;
+              if (blockSolver.state.retryCount < BLOCK_MAX_RETRIES) {
+                blockSolver.state.retryCount += 1;
+                restoreBlockSnapshot();
+              } else {
+                finishBlock(false);
+              }
+              status_bool = true;
+            } else {
+              // Single-pass path (REDGRID, or CITY below the block-solver
+              // threshold) — wipe history and start a fresh grid so the
+              // run can keep making forward progress. status_bool was
+              // turned off by pickAndCollapseOne earlier this frame; flip
+              // it back on so the next frame picks again instead of
+              // stalling with status_bool=false and backtracking=false.
+              old_grids = [];
+              tracking = [];
+              backtracking = false;
+              grid_list = bslider ? createGrid(bslider.value(), true) : [];
+              status_bool = true;
+            }
           }
         } else {
           // Unknown error — log and continue rendering.
@@ -1092,6 +1491,27 @@ function drawImpl() {
 
   renderGrid(grid_list);
   if (slider_text) slider_text.html(bslider.value());
+  updateBlockStatus();
+}
+
+function updateBlockStatus() {
+  const el = document.getElementById('wfc-block-status');
+  if (!el) return;
+  if (!blockSolver) {
+    if (!el.hidden) el.hidden = true;
+    return;
+  }
+  el.hidden = false;
+  const total = blockSolver.blocks.length;
+  // blockIdx is 0-based and points at the *current* block while solving;
+  // bumps to `total` once the final block finishes. Show "X / total"
+  // where X is min(blockIdx+1, total) so the readout never overflows.
+  const human = Math.min(blockSolver.blockIdx + 1, total);
+  const retry = blockSolver.state ? blockSolver.state.retryCount : 0;
+  const done = blockSolver.blockIdx >= total;
+  el.textContent = done
+    ? `blocks ${total} / ${total} · done`
+    : `block ${human} / ${total}${retry > 0 ? ` · retry ${retry}` : ''}`;
 }
 
 // Deterministic p5 bootstrap. See the long comment above the IIFE in the

--- a/tests/e2e/wfc.spec.ts
+++ b/tests/e2e/wfc.spec.ts
@@ -570,4 +570,83 @@ test.describe('WFC interactive widget', () => {
     });
     expect(progress).toBeGreaterThan(0);
   });
+
+  // Block-WFC regression: at CITY grid sizes above 8 the widget activates
+  // Merrell's modification-in-blocks solver (6x6 blocks, stride 5, ground
+  // pre-fill, boundary constraints pre-propagated). Pre-block solver,
+  // sizes 16-30 would auto-restart the whole grid every few seconds and
+  // effectively never finish. This test sets a fixed seed, runs a 16x16
+  // CITY grid to completion, and asserts the final state — proving the
+  // solver makes forward progress past the single-pass cap.
+  test('CITY at grid 16 completes via block solver @multistep', async ({ page }) => {
+    // Seed the run for determinism, but don't freeze the draw loop —
+    // we need it advancing to completion.
+    await page.goto(`${WFC_URL}?seed=42`);
+    await waitForP5Ready(page);
+
+    await page.locator('#tileselect .image-container').filter({ hasText: /CITY/i }).locator('button').click();
+    await expect(page.locator('#STARTWFC')).toBeVisible();
+
+    // Bump the grid size slider to 16 BEFORE clicking STARTWFC so
+    // initBlockSolver picks up the larger size when the run starts.
+    // The slider is created inside startWFC, so it doesn't exist yet —
+    // instead, we click STARTWFC and then resize before any cells are
+    // collapsed. p5's createSlider mounts a native input we can drive
+    // via change events.
+    await page.locator('#STARTWFC').click();
+    await expect(page.locator('#wfc-canvas canvas')).toBeVisible({ timeout: 15_000 });
+
+    // Block solver should be live now with the default slider value (2),
+    // which is below the threshold — so blockSolver is null. Bump the
+    // slider, hit the p5 Restart button to re-init with size 16.
+    await page.evaluate(() => {
+      const slider = document.querySelector('#wfc-primary input[type="range"]') as HTMLInputElement | null;
+      if (!slider) throw new Error('grid-size slider not found');
+      slider.value = '16';
+      slider.dispatchEvent(new Event('input', { bubbles: true }));
+      slider.dispatchEvent(new Event('change', { bubbles: true }));
+      // Trigger the p5 Restart button (status_button.mousePressed = changeState).
+      const w = window as unknown as { changeState: () => void };
+      w.changeState();
+    });
+
+    // Verify the block solver actually activated.
+    const blockActive = await page.evaluate(() => {
+      const w = window as unknown as { blockSolver: unknown };
+      return w.blockSolver !== null;
+    });
+    expect(blockActive).toBe(true);
+
+    // The block status readout should appear.
+    await expect(page.locator('#wfc-block-status')).toBeVisible();
+
+    // Poll for completion. 16x16 = 256 cells, ~30 blocks. Allow up to
+    // 45s on cold CI; locally this finishes in 5–10s.
+    const finished = await page.waitForFunction(
+      () => {
+        const w = window as unknown as {
+          grid_list: Array<{ options: string[] }>;
+        };
+        return w.grid_list.length === 256 && w.grid_list.every(c => c.options.length === 1);
+      },
+      { timeout: 45_000, polling: 250 },
+    );
+    expect(await finished.evaluate(v => v)).toBeTruthy();
+
+    // No orange (zero-option) cells in the final grid — every cell
+    // must have collapsed to exactly one tile (real or ground fallback).
+    const summary = await page.evaluate(() => {
+      const w = window as unknown as {
+        grid_list: Array<{ options: string[] }>;
+      };
+      return {
+        size: w.grid_list.length,
+        collapsed: w.grid_list.filter(c => c.options.length === 1).length,
+        broken: w.grid_list.filter(c => c.options.length === 0).length,
+      };
+    });
+    expect(summary.size).toBe(256);
+    expect(summary.collapsed).toBe(256);
+    expect(summary.broken).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Implements Paul Merrell's **Modification in Blocks** for the CITY tileset, fulfilling the closing promise of the WFC post (`content/posts/wfc.mdx:76-93`). At grid sizes above 8, CITY now uses a 6×6 block solver with stride 5 (1-cell overlap), scan-line traversal, and the all-grass tile `G_G_G_G_G_G_G_G` as the known-good "ground" pre-fill on open block borders.
- Boundary + prior-block-overlap constraints are pre-propagated into each block's modification region before the first collapse, so blocks meet without visible seams. `adjustPossibilities` skips already-fixed cells mid-BFS, so fixed cells only act as constraint sources when seeded explicitly — pre-propagation enforces that.
- Per-block retry budget (24); on exhaustion the block falls back to ground-fill rather than wiping the whole grid. `tracking`/`old_grids` are cleared at block boundaries so single-cell backtracking can't roll back past prior blocks; `reset_neighbours` is block-aware so it doesn't un-fix cells from prior blocks. A `block X / Y` readout under the canvas tracks progress.
- Bonus fix: pre-existing race where `status_bool` was left false on the single-pass wipe path, stalling the draw loop. The catch-handler comment already said "fresh grid so the run can keep making forward progress" — actually making progress required this flip.

## Approach considered & rejected

- **Nested WFC (arXiv:2308.07307)** — cleaner edge inheritance than Merrell's overlap, but requires the tileset to be "complete" in the paper's formal sense; CITY isn't.
- **Pure optimization with no blocks** — at large CITY sizes the failure isn't slowness, it's combinatorial unsolvability of the global problem. Blocks are necessary, not optional.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:e2e` — 119/119 pass across chromium/firefox/webkit/mobile-chrome (one earlier flake on firefox re-ran clean; 3/3 isolated)
- [x] New `@multistep` test `CITY at grid 16 completes via block solver` runs a 16×16 CITY grid to completion (`tests/e2e/wfc.spec.ts:581`)
- [x] Manual: CITY @ grid 16 completes in ~5s; grid 30 in ~20s; REDGRID_HARD @ grid 30 unchanged (block solver correctly inactive)
- [x] Visual: water/grass/sand transitions flow continuously across block boundaries (no seams)

## Trade-offs visible to readers

- At grid 30, the inner WFC search inside a 6×6 block of 107 CITY tiles occasionally exhausts the 24-retry budget. Those blocks ground-fill, producing patches of plain grass. `BLOCK_MAX_RETRIES` is the lever if more visual variety is wanted at the cost of wall-clock time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)